### PR TITLE
[#74] Fix `Clear` menu option

### DIFF
--- a/survey/src/com/gallatinsystems/survey/device/view/FreetextQuestionView.java
+++ b/survey/src/com/gallatinsystems/survey/device/view/FreetextQuestionView.java
@@ -159,6 +159,11 @@ public class FreetextQuestionView extends QuestionView implements
         }
     }
     
+    @Override
+    public void resetQuestion(boolean fireEvent) {
+        resetQuestion(true, fireEvent);
+    }
+    
     private void resetQuestion(boolean clearFields, boolean fireEvent) {
         if (clearFields) {
             freetextEdit.setText("");


### PR DESCRIPTION
- Override parent class' 'resetQuestion', in order to call the
  overloaded one and clear the UI field.
