### PR TITLE
[#149] Disable 'save' property in CheckBox views

### DIFF
--- a/app/src/main/res/layout/preferences.xml
+++ b/app/src/main/res/layout/preferences.xml
@@ -21,7 +21,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
-                android:layout_alignParentRight="true" />
+                android:layout_alignParentRight="true"
+                android:saveEnabled="false"/>
 
             <TextView
                 android:id="@+id/lastuserlabel"
@@ -44,7 +45,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
-                android:layout_alignParentRight="true" />
+                android:layout_alignParentRight="true"
+                android:saveEnabled="false"/>
 
             <TextView
                 android:id="@+id/screenopttxt"
@@ -75,7 +77,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
-                android:layout_alignParentRight="true" />
+                android:layout_alignParentRight="true"
+                android:saveEnabled="false"/>
+
 
             <TextView
                 android:id="@+id/uploadoptionlabel"
@@ -149,7 +153,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
-                android:layout_alignParentRight="true" />
+                android:layout_alignParentRight="true"
+                android:saveEnabled="false"/>
 
             <TextView
                 android:id="@+id/beaconlabel"


### PR DESCRIPTION
- The system will not attempt to restore their state, which essentially
  relies on the DB to be opened.
