### PR TITLE
Hotfix/367 repeatable other

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.akvo.flow"
     android:versionCode="1"
-    android:versionName="2.2.2" >
+    android:versionName="2.2.2.1" >
 
     <uses-sdk
         android:minSdkVersion="10"

--- a/app/src/main/java/org/akvo/flow/domain/AltText.java
+++ b/app/src/main/java/org/akvo/flow/domain/AltText.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2012 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/app/src/main/java/org/akvo/flow/domain/AltText.java
+++ b/app/src/main/java/org/akvo/flow/domain/AltText.java
@@ -26,6 +26,18 @@ public class AltText {
     private String type;
     private String text;
 
+    public AltText() {
+    }
+
+    /**
+     * Copy constructor
+     */
+    public AltText(AltText altText) {
+        this.language = altText.getLanguage();
+        this.type = altText.getType();
+        this.text = altText.getText();
+    }
+
     public String getLanguage() {
         return language;
     }

--- a/app/src/main/java/org/akvo/flow/domain/Option.java
+++ b/app/src/main/java/org/akvo/flow/domain/Option.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2012 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/app/src/main/java/org/akvo/flow/domain/Option.java
+++ b/app/src/main/java/org/akvo/flow/domain/Option.java
@@ -40,7 +40,7 @@ public class Option {
         this.code = option.getCode();
         this.isOther = option.isOther();
         for (AltText altText : option.altTextMap.values()) {
-            this.altTextMap.put(altText.getLanguage(), altText);
+            addAltText(new AltText(altText));// Deep-copy AltText map
         }
     }
 

--- a/app/src/main/java/org/akvo/flow/domain/Option.java
+++ b/app/src/main/java/org/akvo/flow/domain/Option.java
@@ -29,6 +29,21 @@ public class Option {
     private boolean isOther;
     private HashMap<String, AltText> altTextMap = new HashMap<>();
 
+    public Option() {
+    }
+
+    /**
+     * Copy constructor
+     */
+    public Option(Option option) {
+        this.text = option.getText();
+        this.code = option.getCode();
+        this.isOther = option.isOther();
+        for (AltText altText : option.altTextMap.values()) {
+            this.altTextMap.put(altText.getLanguage(), altText);
+        }
+    }
+
     public void addAltText(AltText altText) {
         altTextMap.put(altText.getLanguage(), altText);
     }

--- a/app/src/main/java/org/akvo/flow/domain/Question.java
+++ b/app/src/main/java/org/akvo/flow/domain/Question.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2015 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/app/src/main/java/org/akvo/flow/domain/Question.java
+++ b/app/src/main/java/org/akvo/flow/domain/Question.java
@@ -386,7 +386,6 @@ public class Question {
         q.allowPolygon = question.isAllowPolygon();
         q.src = question.getSrc();
         q.validationRule = question.getValidationRule();// Shallow copy
-        q.options = question.getOptions();// Shallow copy
         q.questionHelp = question.getQuestionHelp();// Shallow copy
         q.altTextMap = question.getAltTextMap();// Shallow copy
         q.scoringRules = question.getScoringRules();// Shallow copy
@@ -397,6 +396,14 @@ public class Question {
             q.dependencies = new ArrayList<>();
             for (Dependency d : question.getDependencies()) {
                 q.dependencies.add(new Dependency(d));
+            }
+        }
+
+        // Deep-copy options
+        if (question.options != null) {
+            q.options = new ArrayList<>();
+            for (Option o : question.options) {
+                q.options.add(new Option(o));
             }
         }
         return q;


### PR DESCRIPTION
Fixed issue described in https://github.com/akvo/akvo-flow-mobile/issues/367#issuecomment-169337708

The problem was that each iteration of the repeatable group was adding the option *OTHER* to the original map. The solution to address this has been to deep-copy the options map when cloning the question for each iteration.