### PR TITLE
Hotfix/2.2.3.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,13 @@
 Akvo FLOW app release notes
 ===========================
 
+# ver 2.2.3.1
+Date: 11 March 2016
+
+Resolved issues
+---------------
+* Ensure cascade responses are always complete [#425]
+
 # ver 2.2.3
 Date: 29 February 2016
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.akvo.flow"
     android:versionCode="1"
-    android:versionName="2.2.3" >
+    android:versionName="2.2.3.1" >
 
     <uses-sdk
         android:minSdkVersion="10"

--- a/app/src/main/java/org/akvo/flow/ui/view/CascadeQuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/CascadeQuestionView.java
@@ -123,7 +123,7 @@ public class CascadeQuestionView extends QuestionView implements AdapterView.OnI
             Node node = (Node)getSpinner(updatedSpinnerIndex).getSelectedItem();
             if (node.getId() == ID_NONE) {
                 // if this is the first level, it means we've got no answer at all
-                mFinished = updatedSpinnerIndex == 0;
+                mFinished = false;
                 return; // Do not load more levels
             } else {
                 parent = node.getId();
@@ -260,9 +260,10 @@ public class CascadeQuestionView extends QuestionView implements AdapterView.OnI
         return (Spinner)mSpinnerContainer.getChildAt(position).findViewById(R.id.spinner);
     }
 
+    @Override
     public boolean isValid() {
-        boolean valid = super.isValid();
-        if (valid && !mFinished) {
+        boolean valid = super.isValid() && mFinished;
+        if (!valid) {
             setError(getResources().getString(R.string.error_question_mandatory));
         }
         return valid;


### PR DESCRIPTION
### Redefine response validity check

In order to consider the response as valid, we check:
* Generic response is valid (`super.isValid()`). This will make sure mandatory questions have a response
* Response is complete (`mFinished`). Partial responses will invalidate the response

Additionally, on line 126 we set the completeness flag to `false`, for the current level has no selection.