### PR TITLE
[#462] copy CaddisflyRes property in repeated question groups

### DIFF
--- a/app/src/main/java/org/akvo/flow/domain/Question.java
+++ b/app/src/main/java/org/akvo/flow/domain/Question.java
@@ -399,6 +399,7 @@ public class Question {
         q.altTextMap = question.getAltTextMap();// Shallow copy
         q.scoringRules = question.getScoringRules();// Shallow copy
         q.levels = question.getLevels();// Shallow copy
+        q.caddisflyRes = question.getCaddisflyRes();
 
         // Deep-copy dependencies
         if (question.dependencies != null) {


### PR DESCRIPTION
copies caddisfly test uuid to the question object.

#### Testplan:
The thing to check is if caddisfly questions work in repeated question groups.
In flowglimmerofhope instance, use surveyid 50234000 (1.9.10 caddisfly test). Check if question 2 ("test chlorine") in the tab "Few C. tests with photos repeated" works.
