### PR TITLE
Same name survey manual import fail (connect #476)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,7 @@ android.applicationVariants.all { variant ->
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
     compile 'com.android.support:appcompat-v7:19.+'
+    compile 'com.android.support:support-annotations:21.0.0'
     compile 'com.google.android.gms:play-services:4.0.30'
     compile 'org.ocpsoft.prettytime:prettytime:3.2.4.Final'
     compile 'com.google.maps.android:android-maps-utils:0.3.3'

--- a/app/src/main/java/org/akvo/flow/service/BootstrapService.java
+++ b/app/src/main/java/org/akvo/flow/service/BootstrapService.java
@@ -20,6 +20,8 @@ import android.app.IntentService;
 import android.content.Intent;
 import android.os.Environment;
 import android.os.Handler;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 import android.widget.Toast;
@@ -136,7 +138,7 @@ public class BootstrapService extends IntentService {
      */
     private void rollback(File zipFile) throws Exception {
         ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFile));
-        ZipEntry entry = null;
+        ZipEntry entry;
         while ((entry = zis.getNextEntry()) != null) {
             String parts[] = entry.getName().split("/");
             String fileName = parts[parts.length - 1];
@@ -193,7 +195,8 @@ public class BootstrapService extends IntentService {
         file.renameTo(new File(file.getAbsolutePath() + ConstantUtil.PROCESSED_OK_SUFFIX));
     }
 
-    private void processSurveyFile(ZipFile zipFile, ZipEntry entry, String filename, String id) throws IOException {
+    private void processSurveyFile(@NonNull ZipFile zipFile, @NonNull ZipEntry entry, @NonNull String filename,
+                                   @NonNull String id) throws IOException {
         String surveyName = filename;
         // we want to avoid duplicate survey names
         String surveyFolderName = generateSurveyFolder(entry);
@@ -246,9 +249,9 @@ public class BootstrapService extends IntentService {
 
     /**
      * Check form app id. Reject the form if it does not belong to the one set up
-     * @param loadedSurvey
+     * @param loadedSurvey survey to verify
      */
-    private void verifyAppId(Survey loadedSurvey) {
+    private void verifyAppId(@NonNull Survey loadedSurvey) {
         final String app = StatusUtil.getApplicationId(this);
         final String formApp = loadedSurvey.getApp();
         if (!TextUtils.isEmpty(app) && !TextUtils.isEmpty(formApp) && !app.equals(formApp)) {
@@ -258,14 +261,15 @@ public class BootstrapService extends IntentService {
         }
     }
 
-    private void updateSurveyStorage(Survey survey) {
+    private void updateSurveyStorage(@NonNull Survey survey) {
         databaseAdapter.addSurveyGroup(survey.getSurveyGroup());
         databaseAdapter.saveSurvey(survey);
         String[] languages = LangsPreferenceUtil.determineLanguages(this, survey);
         databaseAdapter.addLanguages(languages);
     }
 
-    private File generateNewSurveyFile(String filename, String surveyFolderName) {
+    @NonNull
+    private File generateNewSurveyFile(@NonNull String filename, @Nullable String surveyFolderName) {
         File filesDir = FileUtil.getFilesDir(FileType.FORMS);
         if (TextUtils.isEmpty(surveyFolderName)) {
             return new File(filesDir, filename);
@@ -278,7 +282,8 @@ public class BootstrapService extends IntentService {
         }
     }
 
-    private String generateSurveyFileName(String filename, String surveyFolderName) {
+    @NonNull
+    private String generateSurveyFileName(@NonNull String filename, @Nullable String surveyFolderName) {
         StringBuilder sb = new StringBuilder(20);
         if (!TextUtils.isEmpty(surveyFolderName)) {
             sb.append(surveyFolderName);
@@ -288,11 +293,11 @@ public class BootstrapService extends IntentService {
         return sb.toString();
     }
 
-    private String generateSurveyFolder(ZipEntry entry) {
+    @NonNull
+    private String generateSurveyFolder(@NonNull ZipEntry entry) {
         String entryName = entry.getName();
         String entryPaths[] = entryName == null ? new String[0] : entryName.split(File.separator);
-        String surveyFolderName = entryPaths.length < 2 ? "" : entryPaths[entryPaths.length - 2];
-        return surveyFolderName;
+        return entryPaths.length < 2 ? "" : entryPaths[entryPaths.length - 2];
     }
 
     /**
@@ -324,7 +329,7 @@ public class BootstrapService extends IntentService {
      * directory
      */
     private ArrayList<File> getZipFiles() {
-        ArrayList<File> zipFiles = new ArrayList<File>();
+        ArrayList<File> zipFiles = new ArrayList<>();
         // zip files can only be loaded on the SD card (not internal storage) so
         // we only need to look there
         if (Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState())) {

--- a/app/src/main/java/org/akvo/flow/util/ConstantUtil.java
+++ b/app/src/main/java/org/akvo/flow/util/ConstantUtil.java
@@ -38,6 +38,7 @@ public class ConstantUtil {
     public static final String STACKTRACE_FILENAME = "err-";
     public static final String STACKTRACE_SUFFIX = ".stacktrace";
     public static final String CASCADE_RES_SUFFIX = ".sqlite.zip";
+    public static final String DOT_SEPARATOR = ".";
 
     /**
      * survey file locations


### PR DESCRIPTION
The survey name xml file was overwritten due to the fact that 2 or more survey forms had the same name.

Have included the folder name (survey id) as a file path for the form xml file to make sure the survey xml file is unique.

Also included new android annotations librabry:
https://developer.android.com/studio/write/annotations.html

This allows you to add annotations such as @Nullable and @NonNull or @StringRes and then run Inspect code and that way avoid bugs and crashes.

Test Plan:
Test manual importing surveys using the zipfiles especially with surveys that have same form names.