### PR TITLE
Stop showing "logged in as " all the time the activity is created (connect #498)

### DIFF
--- a/app/src/main/java/org/akvo/flow/activity/SurveyActivity.java
+++ b/app/src/main/java/org/akvo/flow/activity/SurveyActivity.java
@@ -133,7 +133,6 @@ public class SurveyActivity extends ActionBarActivity implements RecordListListe
             startActivityForResult(new Intent(this, AddUserActivity.class), REQUEST_ADD_USER);
         }
 
-        displaySelectedUser();
         startServices(noDevIdYet);
     }
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Logged in as xxx is shown every time the user rotates the screen. This is not useful.
#### The solution
stop calling displaySelectedUser() in onCreate
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation

