### PR TITLE
Allow searching any place for the datapoint name (connect #467)

### DIFF
--- a/app/src/main/java/org/akvo/flow/dao/DataProvider.java
+++ b/app/src/main/java/org/akvo/flow/dao/DataProvider.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo FLOW.
+ *
+ * Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ * the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ * either version 3 of the License or any later version.
+ *
+ * Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License included below for more details.
+ *
+ * The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ *
+ */
+
 package org.akvo.flow.dao;
 
 import android.app.SearchManager;
@@ -7,6 +24,8 @@ import android.content.UriMatcher;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import org.akvo.flow.app.FlowApp;
 import org.akvo.flow.dao.SurveyDbAdapter.DatabaseHelper;
@@ -50,8 +69,10 @@ public class DataProvider extends ContentProvider {
                 // Suggestions search
                 // Adjust incoming query to become SQL text match
                 long surveyGroupId = FlowApp.getApp().getSurveyGroupId();
-                
-                final String term = selectionArgs[0] + "%";
+
+                String nameSearchTerm = createNameSearchTerm(selectionArgs);
+                String idSearchTerm = createIdSearchTerm(selectionArgs);
+
                 projection = new String[] {
                         RecordColumns._ID,
                         RecordColumns.RECORD_ID
@@ -64,7 +85,7 @@ public class DataProvider extends ContentProvider {
                     Tables.RECORD,
                     projection,
                     SUGGEST_SELECTION,
-                    new String[]{String.valueOf(surveyGroupId), term, term},
+                    new String[]{String.valueOf(surveyGroupId), idSearchTerm, nameSearchTerm},
                     null, null, sortOrder);
                 break;
         }
@@ -75,6 +96,27 @@ public class DataProvider extends ContentProvider {
         }
         
         return cursor;    
+    }
+
+    @NonNull
+    private String createIdSearchTerm(@Nullable String[] selectionArgs) {
+        StringBuilder recordIdSearchBuilder = new StringBuilder();
+        if (selectionArgs != null && selectionArgs.length > 0) {
+            recordIdSearchBuilder.append(selectionArgs[0]);
+        }
+        recordIdSearchBuilder.append("%");
+        return recordIdSearchBuilder.toString();
+    }
+
+    @NonNull
+    private String createNameSearchTerm(@Nullable String[] selectionArgs) {
+        StringBuilder nameSearchBuilder = new StringBuilder();
+        nameSearchBuilder.append("%");
+        if (selectionArgs != null && selectionArgs.length > 0) {
+            nameSearchBuilder.append(selectionArgs[0]);
+        }
+        nameSearchBuilder.append("%");
+        return nameSearchBuilder.toString();
     }
 
     @Override


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
If you wanted to search a datapoint the search was made starting at the beginning of the word.
A name like 'Barcelona - 50' would never be found if you search by '50'.
#### The solution
Made it possible to search for the name anywhere even if the name is composed of multiple items.
#### Screenshots (if appropriate)
![screenshot_20161202-163337](https://cloud.githubusercontent.com/assets/923280/20840960/550eccc2-b8b2-11e6-8909-0550db1ae226.png)

#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation

…inning