### PR TITLE
Fixed crash in About dialog (connect #545)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,7 +32,7 @@
     <string name="aboutlabel">About</string>
     <string name="aboutdesc">Displays version information.</string>
     <string name="abouttitle">About - Akvo FLOW app</string>
-    <string name="about_text">Akvo FLOW app\nDeveloped By: Akvo Foundation\nCopyright © 2010-%1$d Stichting Akvo\nVersion %2$s</string>
+    <string name="about_text">Akvo FLOW app\nDeveloped By: Akvo Foundation\nCopyright © 2010-%1$s Stichting Akvo\nVersion %2$s</string>
     <string name="gpsstatuslabel">GPS Status</string>
     <string name="gpsstatusdesc">Launches the GPS Status application if you have it installed on this device.</string>
     <string name="nogpsstatus">GPS Status is not installed on this device. Please install it using the Google Play Store.</string>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
There was a crash due to the string formatter expecting a number while we provided a string
#### The solution
Specified we expect a string arg
#### Screenshots (if appropriate)
NA 
#### Reviewer Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation

