### PR TITLE
Form name wrap issue (connect #521)

### DIFF
--- a/app/src/main/java/org/akvo/flow/activity/RecordActivity.java
+++ b/app/src/main/java/org/akvo/flow/activity/RecordActivity.java
@@ -50,8 +50,6 @@ public class RecordActivity extends BackActivity implements SurveyListListener, 
     public static final String EXTRA_SURVEY_GROUP = "survey_group";
     public static final String EXTRA_RECORD_ID = "record";
     
-    //private static final String TAG = RecordActivity.class.getSimpleName();
-    
     private static final int POSITION_SURVEYS = 0;
     private static final int POSITION_RESPONSES = 1;
 
@@ -175,7 +173,7 @@ public class RecordActivity extends BackActivity implements SurveyListListener, 
         public Fragment getItem(int position) {
             switch (position) {
                 case POSITION_SURVEYS:
-                    return FormListFragment.instantiate(mSurveyGroup, mRecord);
+                    return FormListFragment.newInstance(mSurveyGroup, mRecord);
                 case POSITION_RESPONSES:
                     return ResponseListFragment.instantiate(mSurveyGroup, mRecord);
             }

--- a/app/src/main/java/org/akvo/flow/activity/RecordActivity.java
+++ b/app/src/main/java/org/akvo/flow/activity/RecordActivity.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2013-2015 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2013-2016 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -49,7 +49,7 @@ public class RecordActivity extends BackActivity implements SurveyListListener, 
         RecordListListener {
     public static final String EXTRA_SURVEY_GROUP = "survey_group";
     public static final String EXTRA_RECORD_ID = "record";
-    
+
     private static final int POSITION_SURVEYS = 0;
     private static final int POSITION_RESPONSES = 1;
 
@@ -59,18 +59,18 @@ public class RecordActivity extends BackActivity implements SurveyListListener, 
     private SurveyedLocale mRecord;
     private SurveyGroup mSurveyGroup;
     private SurveyDbAdapter mDatabase;
-    
+
     private ViewPager mPager;
 
     private String[] mTabs;
-    
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.record_activity);
-        
+
         mTabs = getResources().getStringArray(R.array.record_tabs);
-        mPager = (ViewPager)findViewById(R.id.pager);
+        mPager = (ViewPager) findViewById(R.id.pager);
         mPager.setAdapter(new TabsAdapter(getSupportFragmentManager()));
         mPager.setOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
             @Override
@@ -78,15 +78,16 @@ public class RecordActivity extends BackActivity implements SurveyListListener, 
                 getSupportActionBar().setSelectedNavigationItem(position);
             }
         });
-        
+
         mDatabase = new SurveyDbAdapter(this);
-        
+
         mSurveyGroup = (SurveyGroup) getIntent().getSerializableExtra(EXTRA_SURVEY_GROUP);
         setTitle(mSurveyGroup.getName());
-        
+
         setupActionBar();
     }
-    
+
+    //TODO: replace deprecated Tabs
     private void setupActionBar() {
         final ActionBar actionBar = getSupportActionBar();
         actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_TABS);
@@ -101,7 +102,7 @@ public class RecordActivity extends BackActivity implements SurveyListListener, 
         actionBar.addTab(listTab);
         actionBar.addTab(responsesTab);
     }
-    
+
     @Override
     public void onResume() {
         super.onResume();
@@ -146,8 +147,11 @@ public class RecordActivity extends BackActivity implements SurveyListListener, 
         // Check if there are saved (non-submitted) responses for this Survey, and take the 1st one
         long[] instances = mDatabase.getFormInstances(mRecord.getId(), surveyId,
                 SurveyInstanceStatus.SAVED);
-        long instance = instances.length > 0 ? instances[0]
-                : mDatabase.createSurveyRespondent(surveyId, survey.getVersion(), mUser, mRecord.getId());
+        long instance = instances.length > 0 ?
+                instances[0]
+                :
+                mDatabase.createSurveyRespondent(surveyId, survey.getVersion(), mUser,
+                        mRecord.getId());
 
         Intent i = new Intent(this, FormActivity.class);
         i.putExtra(ConstantUtil.USER_ID_KEY, mUser.getId());
@@ -159,7 +163,7 @@ public class RecordActivity extends BackActivity implements SurveyListListener, 
     }
 
     class TabsAdapter extends FragmentPagerAdapter {
-        
+
         public TabsAdapter(FragmentManager fm) {
             super(fm);
         }
@@ -168,7 +172,7 @@ public class RecordActivity extends BackActivity implements SurveyListListener, 
         public int getCount() {
             return mTabs.length;
         }
-        
+
         @Override
         public Fragment getItem(int position) {
             switch (position) {
@@ -177,21 +181,21 @@ public class RecordActivity extends BackActivity implements SurveyListListener, 
                 case POSITION_RESPONSES:
                     return ResponseListFragment.instantiate(mSurveyGroup, mRecord);
             }
-            
+
             return null;
         }
-        
+
         @Override
         public CharSequence getPageTitle(int position) {
             return mTabs[position];
         }
-        
+
     }
-    
+
     // ==================================== //
     // =========== Options Menu =========== //
     // ==================================== //
-    
+
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.datapoint_activity, menu);
@@ -209,7 +213,7 @@ public class RecordActivity extends BackActivity implements SurveyListListener, 
                 return super.onOptionsItemSelected(item);
         }
     }
-    
+
     @Override
     public void onTabReselected(Tab tab, FragmentTransaction fragmentTransaction) {
     }

--- a/app/src/main/res/layout/survey_item.xml
+++ b/app/src/main/res/layout/survey_item.xml
@@ -1,33 +1,24 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:minHeight="?android:attr/listPreferredItemHeight"
-    android:gravity="center_vertical"
-    android:padding="8dp" >
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                xmlns:tools="http://schemas.android.com/tools"
+                android:minHeight="?android:attr/listPreferredItemHeight"
+                android:gravity="center_vertical"
+                android:padding="8dp">
 
     <TextView
-        android:id="@+id/text1"
+        android:id="@+id/survey_name_tv"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textSize="22sp" />
-
-    <TextView
-        android:id="@+id/text2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_toRightOf="@id/text1"
-        android:layout_toEndOf="@id/text1"
-        android:layout_alignBaseline="@+id/text1"
-        android:enabled="false"
-        android:textSize="18sp" />
+        android:textColor="@color/text_color_primary"
+        tools:text="Farmer Rice Diary: Pest - Disease"
+        tools:textSize="22sp" />
 
     <TextView
         android:id="@+id/date_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/text1"
+        android:layout_below="@id/survey_name_tv"
         android:layout_marginRight="5dp"
         android:layout_marginEnd="5dp"
         android:textSize="18sp"
@@ -38,7 +29,7 @@
         android:id="@+id/date"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/text1"
+        android:layout_below="@id/survey_name_tv"
         android:layout_toRightOf="@+id/date_label"
         android:layout_toEndOf="@+id/date_label"
         android:textSize="18sp"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -6,4 +6,7 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
 
+    <dimen name="survey_version_text_size">18sp</dimen>
+    <dimen name="survey_title_text_size">22sp</dimen>
+
 </resources>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Form name was not bieng wrapped in some cases due to the fact that 2 diferent textviews were being used and if the first one was too large, the second one was displayed in a strange way (see screenshots on the issue)
#### The solution
Use spannable and only one TextView to prevent that issue. Spannable allows to have diferent text sizes within one textView for example.
#### Screenshots (if appropriate)
![screenshot from 2016-12-14 18-45-09](https://cloud.githubusercontent.com/assets/923280/21193836/ecf3081c-c22d-11e6-920a-0af8e7765ef5.png)

#### Reviewer Checklist
* [x] Connect the issue
* [x] Test plan
* [x] Copyright header
* [x] Code formatting
* [x] Documentation
