### PR TITLE
Cascade long text wrap (connect #568)

### DIFF
--- a/app/src/main/java/org/akvo/flow/ui/view/CascadeQuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/CascadeQuestionView.java
@@ -45,11 +45,11 @@ import org.akvo.flow.util.FileUtil;
 import org.akvo.flow.util.FileUtil.FileType;
 
 import java.io.File;
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
-public class CascadeQuestionView extends QuestionView implements AdapterView.OnItemSelectedListener {
+public class CascadeQuestionView extends QuestionView
+        implements AdapterView.OnItemSelectedListener {
     private static final String TAG = CascadeQuestionView.class.getSimpleName();
     private static final int POSITION_NONE = -1;// no spinner position id
 
@@ -70,13 +70,13 @@ public class CascadeQuestionView extends QuestionView implements AdapterView.OnI
     private void init() {
         setQuestionView(R.layout.cascade_question_view);
 
-        mSpinnerContainer = (LinearLayout)findViewById(R.id.cascade_content);
+        mSpinnerContainer = (LinearLayout) findViewById(R.id.cascade_content);
 
         // Load level names
         List<Level> levels = getQuestion().getLevels();
         if (levels != null) {
             mLevels = new String[levels.size()];
-            for (int i=0; i<levels.size(); i++) {
+            for (int i = 0; i < levels.size(); i++) {
                 mLevels[i] = levels.get(i).getText();
             }
         }
@@ -121,7 +121,7 @@ public class CascadeQuestionView extends QuestionView implements AdapterView.OnI
 
         long parent = ID_ROOT;
         if (updatedSpinnerIndex != POSITION_NONE) {
-            Node node = (Node)getSpinner(updatedSpinnerIndex).getSelectedItem();
+            Node node = (Node) getSpinner(updatedSpinnerIndex).getSelectedItem();
             if (node.getId() == ID_NONE) {
                 // if this is the first level, it means we've got no answer at all
                 mFinished = false;
@@ -148,8 +148,8 @@ public class CascadeQuestionView extends QuestionView implements AdapterView.OnI
         LayoutInflater inflater = LayoutInflater.from(getContext());
 
         View view = inflater.inflate(R.layout.cascading_level_item, mSpinnerContainer, false);
-        final TextView text = (TextView)view.findViewById(R.id.text);
-        final Spinner spinner = (Spinner)view.findViewById(R.id.spinner);
+        final TextView text = (TextView) view.findViewById(R.id.text);
+        final Spinner spinner = (Spinner) view.findViewById(R.id.spinner);
 
         text.setText(mLevels != null && mLevels.length > position ? mLevels[position] : "");
 
@@ -175,7 +175,7 @@ public class CascadeQuestionView extends QuestionView implements AdapterView.OnI
 
     @Override
     public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-        final int index = (Integer)parent.getTag();
+        final int index = (Integer) parent.getTag();
         updateSpinners(index);
         captureResponse();
         setError(null);
@@ -205,7 +205,7 @@ public class CascadeQuestionView extends QuestionView implements AdapterView.OnI
         while (index < values.size()) {
             int valuePosition = POSITION_NONE;
             List<Node> spinnerValues = mDatabase.getValues(parentId);
-            for (int pos=0; pos<spinnerValues.size(); pos++) {
+            for (int pos = 0; pos < spinnerValues.size(); pos++) {
                 Node node = spinnerValues.get(pos);
                 CascadeNode v = values.get(index);
                 if (node.getName().equals(v.getName())) {
@@ -242,8 +242,8 @@ public class CascadeQuestionView extends QuestionView implements AdapterView.OnI
     @Override
     public void captureResponse(boolean suppressListeners) {
         List<CascadeNode> values = new ArrayList<>();
-        for (int i=0; i<mSpinnerContainer.getChildCount(); i++) {
-            Node node = (Node)getSpinner(i).getSelectedItem();
+        for (int i = 0; i < mSpinnerContainer.getChildCount(); i++) {
+            Node node = (Node) getSpinner(i).getSelectedItem();
             if (node.getId() != ID_NONE) {
                 CascadeNode v = new CascadeNode();
                 v.setName(node.getName());
@@ -258,7 +258,7 @@ public class CascadeQuestionView extends QuestionView implements AdapterView.OnI
     }
 
     private Spinner getSpinner(int position) {
-        return (Spinner)mSpinnerContainer.getChildAt(position).findViewById(R.id.spinner);
+        return (Spinner) mSpinnerContainer.getChildAt(position).findViewById(R.id.spinner);
     }
 
     @Override
@@ -273,36 +273,27 @@ public class CascadeQuestionView extends QuestionView implements AdapterView.OnI
     private static class CascadeAdapter extends ArrayAdapter<Node> {
 
         CascadeAdapter(Context context, List<Node> objects) {
-            super(context, android.R.layout.simple_spinner_item, objects);
-            setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+            super(context, R.layout.cascade_spinner_item, R.id.cascade_spinner_item_text, objects);
+            setDropDownViewResource(R.layout.cascade_spinner_item);
         }
 
         @Override
-        public View getView (int position, View convertView, ViewGroup parent) {
+        public View getView(int position, View convertView, ViewGroup parent) {
             View view = super.getView(position, convertView, parent);
             setStyle(view, position);
             return view;
         }
 
         @Override
-        public View getDropDownView (final int position, View convertView, ViewGroup parent) {
+        public View getDropDownView(final int position, View convertView, ViewGroup parent) {
             View view = super.getDropDownView(position, convertView, parent);
             setStyle(view, position);
-            if (view instanceof TextView) {
-                final TextView finalItem = (TextView) view;
-                view.post(new CascadeTextViewRunnable(finalItem, position, getCount() - 1));
-            }
-            if (position == getCount() - 1) {
-                parent.setPadding(parent.getPaddingLeft(), parent.getPaddingTop(),
-                        parent.getPaddingRight(), parent.getResources()
-                                .getDimensionPixelSize(R.dimen.cascade_bottom_margin));
-            }
             return view;
         }
 
         private void setStyle(View view, int position) {
             try {
-                TextView text = (TextView)view;
+                TextView text = (TextView) view.findViewById(R.id.cascade_spinner_item_text);
                 int flags = text.getPaintFlags();
                 if (position == 0) {
                     flags |= Paint.FAKE_BOLD_TEXT_FLAG;
@@ -312,32 +303,6 @@ public class CascadeQuestionView extends QuestionView implements AdapterView.OnI
                 text.setPaintFlags(flags);
             } catch (ClassCastException e) {
                 Log.e("CascadeAdapter", "View cannot be casted to TextView!");
-            }
-        }
-
-        private static class CascadeTextViewRunnable implements Runnable {
-            private final WeakReference<TextView> textViewWeakReference;
-            private final int position;
-            private final int lastPosition;
-
-            public CascadeTextViewRunnable(TextView finalItem, int position, int lastPosition) {
-                this.textViewWeakReference = new WeakReference<>(finalItem);
-                this.position = position;
-                this.lastPosition = lastPosition;
-            }
-
-            @Override
-            public void run() {
-                TextView finalItem = textViewWeakReference.get();
-                if (finalItem != null) {
-                    finalItem.setSingleLine(false);
-//                    if (position == lastPosition) {
-//                        ViewGroup.LayoutParams params = finalItem.getLayoutParams();
-//                        finalItem.setPadding(finalItem.getPaddingLeft(), finalItem.getPaddingTop(),
-//                                finalItem.getPaddingRight(), finalItem.getResources()
-//                                        .getDimensionPixelSize(R.dimen.cascade_bottom_margin));
-//                    }
-                }
             }
         }
     }

--- a/app/src/main/res/layout/cascade_spinner_item.xml
+++ b/app/src/main/res/layout/cascade_spinner_item.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+          android:id="@android:id/text1"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"/>

--- a/app/src/main/res/layout/cascade_spinner_item.xml
+++ b/app/src/main/res/layout/cascade_spinner_item.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-          android:id="@android:id/text1"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"/>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:orientation="vertical">
+    <TextView
+            android:id="@+id/cascade_spinner_item_text"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginRight="8dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+</LinearLayout>

--- a/app/src/main/res/layout/cascading_level_item.xml
+++ b/app/src/main/res/layout/cascading_level_item.xml
@@ -13,6 +13,7 @@
 
     <Spinner
             android:id="@+id/spinner"
+            android:spinnerMode="dropdown"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 

--- a/app/src/main/res/layout/cascading_level_item.xml
+++ b/app/src/main/res/layout/cascading_level_item.xml
@@ -1,19 +1,19 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical" >
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:orientation="vertical">
 
     <TextView
-        android:id="@+id/text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center_vertical"
-        android:textStyle="bold"
-        android:textSize="18sp" />
+            android:id="@+id/text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:textStyle="bold"
+            android:textSize="18sp"/>
 
     <Spinner
-        android:id="@+id/spinner"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+            android:id="@+id/spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
 
 </LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -9,4 +9,6 @@
     <dimen name="survey_version_text_size">18sp</dimen>
     <dimen name="survey_title_text_size">22sp</dimen>
 
+    <dimen name="cascade_bottom_margin">16dp</dimen>
+
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -9,6 +9,4 @@
     <dimen name="survey_version_text_size">18sp</dimen>
     <dimen name="survey_title_text_size">22sp</dimen>
 
-    <dimen name="cascade_bottom_margin">16dp</dimen>
-
 </resources>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When cascades had a too long name, only the first line was shown
#### The solution
Make cascade layout use a custom layout to display all the cascade item text
#### Screenshots (if appropriate)
![screenshot_1482318391](https://cloud.githubusercontent.com/assets/923280/21387035/0f4bdbee-c776-11e6-8f59-96885b52e2fe.png)

#### Additional info
The styling will be fixed with the issue #559 
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
