### PR TITLE
Fixed dialog was not being displayed in the first 24 hours (connect #578)

### DIFF
--- a/app/src/main/java/org/akvo/flow/app/FlowApp.java
+++ b/app/src/main/java/org/akvo/flow/app/FlowApp.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2013-2015 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2013-2017 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -57,7 +57,7 @@ public class FlowApp extends Application {
     }
 
     private void startUpdateService() {
-        ApkUpdateService.scheduleRepeat(this);
+        ApkUpdateService.scheduleFirstTask(this);
     }
 
     public static FlowApp getApp() {

--- a/app/src/main/java/org/akvo/flow/service/ApkUpdateService.java
+++ b/app/src/main/java/org/akvo/flow/service/ApkUpdateService.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
+* Copyright (C) 2010-2017 Stichting Akvo (Akvo Foundation)
 *
 * This file is part of Akvo FLOW.
 *
@@ -55,14 +55,14 @@ public class ApkUpdateService extends GcmTaskService {
     }
 
     private static void schedulePeriodicTask(Context context, int repeatIntervalInSeconds,
-            int flexInSeconds) {
+            int flexIntervalInSeconds) {
         try {
             PeriodicTask periodic = new PeriodicTask.Builder()
                     .setService(ApkUpdateService.class)
                     //repeat every x seconds
                     .setPeriod(repeatIntervalInSeconds)
                     //specify how much earlier the task can be executed (in seconds)
-                    .setFlex(flexInSeconds)
+                    .setFlex(flexIntervalInSeconds)
                     .setTag(TAG)
                     //whether the task persists after device reboot
                     .setPersisted(true)

--- a/app/src/main/java/org/akvo/flow/util/ConstantUtil.java
+++ b/app/src/main/java/org/akvo/flow/util/ConstantUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
+ * Copyright (C) 2010-2017 Stichting Akvo (Akvo Foundation)
  *
  * This file is part of Akvo FLOW.
  *
@@ -247,7 +247,11 @@ public class ConstantUtil {
 
     //apk update
     public static final int REPEAT_INTERVAL_IN_SECONDS = 1 * 60 * 60 * 24; //every 24Hrs
-    public static final int FLEX_IN_SECONDS = 1 * 60 * 60; //1 hour
+    public static final int FLEX_INTERVAL_IN_SECONDS = 1 * 60 * 60; //1 hour
+
+    //first runs will be faster
+    public static final int FIRST_REPEAT_INTERVAL_IN_SECONDS = 1 * 60;
+    public static final int FIRST_FLEX_INTERVAL_IN_SECOND = 30;
 
     /**
      * 7 days


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
There was an issue and the dialog was not being displayed in the first 24hours. The reason for that is that I think is since the task is scheduled within 24 hours, if in the meantime the app is restart, the task is rescheduled for another 24hours.
#### The solution
The fist task will run within 1 minute and then consecutive runs will be every 24 hours. If the app is restarted, the task will run immediately.
#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
