### PR TITLE
Fixing the geoshape image button styling (connect #597)

### DIFF
--- a/app/src/main/java/org/akvo/flow/activity/GeoshapeActivity.java
+++ b/app/src/main/java/org/akvo/flow/activity/GeoshapeActivity.java
@@ -22,7 +22,7 @@ import android.graphics.Color;
 import android.location.Location;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Menu;
@@ -35,8 +35,8 @@ import android.widget.Toast;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.GoogleMap.OnMapLongClickListener;
-import com.google.android.gms.maps.GoogleMap.OnMarkerDragListener;
 import com.google.android.gms.maps.GoogleMap.OnMarkerClickListener;
+import com.google.android.gms.maps.GoogleMap.OnMarkerDragListener;
 import com.google.android.gms.maps.GoogleMap.OnMyLocationChangeListener;
 import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
@@ -59,9 +59,9 @@ import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
 
-public class GeoshapeActivity extends ActionBarActivity
-    implements OnMapLongClickListener, OnMarkerDragListener, OnMarkerClickListener, OnMyLocationChangeListener,
-    OnMapReadyCallback {
+public class GeoshapeActivity extends AppCompatActivity
+        implements OnMapLongClickListener, OnMarkerDragListener, OnMarkerClickListener,
+        OnMyLocationChangeListener, OnMapReadyCallback {
 
     private static final String JSON_TYPE = "type";
     private static final String JSON_GEOMETRY = "geometry";

--- a/app/src/main/java/org/akvo/flow/activity/GeoshapeActivity.java
+++ b/app/src/main/java/org/akvo/flow/activity/GeoshapeActivity.java
@@ -1,17 +1,21 @@
 /*
- *  Copyright (C) 2015 Stichting Akvo (Akvo Foundation)
+ * Copyright (C) 2015-2017 Stichting Akvo (Akvo Foundation)
  *
- *  This file is part of Akvo FLOW.
+ * This file is part of Akvo Flow.
  *
- *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
- *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
- *  either version 3 of the License or any later version.
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *  See the GNU Affero General Public License included below for more details.
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.akvo.flow.activity;
 

--- a/app/src/main/res/drawable/image_button_background.xml
+++ b/app/src/main/res/drawable/image_button_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true" android:drawable="@drawable/image_button_selected" />
+    <item android:state_focused="true" android:drawable="@drawable/image_button_selected" />
+    <item android:state_enabled="false" android:drawable="@drawable/image_button_disabled" />
+    <item android:drawable="@drawable/image_button_normal"/>
+</selector>

--- a/app/src/main/res/drawable/image_button_disabled.xml
+++ b/app/src/main/res/drawable/image_button_disabled.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="rectangle">
+    <solid android:color="@color/image_button_grey_disabled"/>
+    <corners android:radius="2dp"/>
+</shape>

--- a/app/src/main/res/drawable/image_button_normal.xml
+++ b/app/src/main/res/drawable/image_button_normal.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="rectangle">
+    <solid android:color="@color/image_button_grey"/>
+    <corners android:radius="2dp"/>
+</shape>

--- a/app/src/main/res/drawable/image_button_selected.xml
+++ b/app/src/main/res/drawable/image_button_selected.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="rectangle">
+    <solid android:color="@color/image_button_grey_selected"/>
+    <corners android:radius="2dp"/>
+</shape>

--- a/app/src/main/res/layout/geoshape_activity.xml
+++ b/app/src/main/res/layout/geoshape_activity.xml
@@ -1,74 +1,73 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+                xmlns:tools="http://schemas.android.com/tools"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
     <fragment
-        android:id="@+id/map"
-        android:name="com.google.android.gms.maps.SupportMapFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+            android:id="@+id/map"
+            android:name="com.google.android.gms.maps.SupportMapFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
 
     <TextView
-        android:id="@+id/accuracy"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:padding="8dp"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true"
-        android:textSize="16sp" />
-
-    <RelativeLayout
-        android:id="@+id/feature_menu"
-        android:layout_width="match_parent"
-        android:layout_height="48dp"
-        android:layout_alignParentBottom="true"
-        android:background="@color/feature_menu_background"
-        android:visibility="gone" >
-
-        <TextView
-            android:id="@+id/feature_name"
+            android:id="@+id/accuracy"
             android:layout_width="wrap_content"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="8dp"
             android:layout_alignParentLeft="true"
             android:layout_alignParentStart="true"
-            android:layout_marginLeft="10dp"
-            android:layout_marginStart="10dp"
-            android:gravity="center"
-            android:textSize="18sp"
-            android:textColor="@color/white"/>
+            android:layout_alignParentTop="true"
+            android:textSize="16sp"/>
+
+    <RelativeLayout
+            android:id="@+id/feature_menu"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:layout_alignParentBottom="true"
+            android:background="@color/feature_menu_background"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+        <TextView
+                android:id="@+id/feature_name"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_marginLeft="10dp"
+                android:layout_marginStart="10dp"
+                android:gravity="center"
+                android:textSize="18sp"
+                android:textColor="@color/white"/>
 
         <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_alignParentRight="true"
-            android:layout_alignParentEnd="true"
-            android:gravity="center">
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentEnd="true"
+                android:gravity="center">
 
             <ImageButton
-                android:id="@+id/properties"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_info_path" />
+                    android:id="@+id/properties"
+                    android:src="@drawable/ic_info_path"
+                    style="@style/ImageButtonStyle"/>
 
             <ImageButton
-                android:id="@+id/add_point_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_add_point" />
+                    android:id="@+id/add_point_btn"
+                    android:src="@drawable/ic_add_point"
+                    style="@style/ImageButtonStyle"/>
 
             <ImageButton
-                android:id="@+id/clear_point_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_delete_point"/>
+                    android:id="@+id/clear_point_btn"
+                    android:src="@drawable/ic_delete_point"
+                    tools:enabled="false"
+                    style="@style/ImageButtonStyle"/>
 
             <ImageButton
-                android:id="@+id/clear_feature_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_delete_feature" />
+                    android:id="@+id/clear_feature_btn"
+                    android:src="@drawable/ic_delete_feature"
+                    style="@style/ImageButtonStyle"/>
 
         </LinearLayout>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -19,6 +19,9 @@
     <color name="button_grey_light_selected">#808285</color>
     <color name="button_grey_dark">#79736e</color>
     <color name="button_grey_dark_selected">#000000</color>
+    <color name="image_button_grey_disabled">#5094918e</color>
+    <color name="image_button_grey">#94918e</color>
+    <color name="image_button_grey_selected">#85827f</color>
 
     <!-- FLOW branding -->
     <color name="background_main">#fffef2e7</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -61,4 +61,13 @@
         <item name="colorControlNormal">@color/black_disabled</item>
     </style>
 
+    <style name="ImageButtonStyle">
+        <item name="android:background">@drawable/image_button_background</item>
+        <item name="android:padding">4dp</item>
+        <item name="android:layout_marginRight">4dp</item>
+        <item name="android:layout_marginEnd">4dp</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
The geoshape bottom image buttons started to look disabled after support library update
#### The solution
created new background and styling for the image buttons
#### Screenshots (if appropriate)
In the screenshot, you can see that the 3rd button is disabled which is normal.
![geoshapeimagebuttons](https://cloud.githubusercontent.com/assets/923280/21991651/bb7bc404-dc13-11e6-8118-bfee487815aa.png)

#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
