### PR TITLE
Removed notifications for Data sync when no errors (connect #584)

### DIFF
--- a/app/src/main/java/org/akvo/flow/util/ConstantUtil.java
+++ b/app/src/main/java/org/akvo/flow/util/ConstantUtil.java
@@ -219,7 +219,6 @@ public class ConstantUtil {
     public static final int IMAGE_SIZE_1280_960 = 2;
 
     public static final int NOTIFICATION_RECORD_SYNC = 100;
-    public static final int NOTIFICATION_DATA_SYNC = 101;
 
     public static final int NOTIFICATION_FORMS_SYNCED = 102;
     public static final int NOTIFICATION_ASSIGNMENT_ERROR = 103;

--- a/app/src/main/java/org/akvo/flow/util/NotificationHelper.java
+++ b/app/src/main/java/org/akvo/flow/util/NotificationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
+ * Copyright (C) 2016-2017 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo Flow.
  *
@@ -63,28 +63,6 @@ public class NotificationHelper {
     public static void displayNonOnGoingErrorNotification(Context context, int notificationId, String text, String title) {
         NotificationCompat.Builder builder = createErrorNotificationBuilder(title, text, context);
         builder.setOngoing(false);
-
-        notifyWithDummyIntent(context, notificationId, builder);
-    }
-
-    public static void displayProgressNotification(Context context, int synced, int total, String title, String text,
-                                                   int notificationId) {
-        NotificationCompat.Builder builder = createNotificationBuilder(title, text, context);
-        builder.setOngoing(true);
-
-        // Progress will only be displayed in Android versions > 4.0
-        builder.setProgress(total, synced, false);
-
-        notifyWithDummyIntent(context, notificationId, builder);
-    }
-
-    public static void displayNonOngoingNotificationWithProgress(Context context, String text, String title,
-                                                                 int notificationId) {
-        NotificationCompat.Builder builder = createNotificationBuilder(title, text, context);
-        builder.setOngoing(false);
-
-        // Progress will only be displayed in Android versions > 4.0
-        builder.setProgress(1, 1, false);
 
         notifyWithDummyIntent(context, notificationId, builder);
     }


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Too many notifications are displayed
#### The solution
Remove notification when data sync after creating survey. Only error notifications will be shown.
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
