### PR TITLE
Fixed BadTokenException when display Gps disabled Dialog (connect #656)

### DIFF
--- a/app/src/main/java/org/akvo/flow/ui/Navigator.java
+++ b/app/src/main/java/org/akvo/flow/ui/Navigator.java
@@ -167,4 +167,8 @@ public class Navigator {
         context.startActivity(new Intent(context, TransmissionHistoryActivity.class)
                 .putExtra(ConstantUtil.RESPONDENT_ID_KEY, surveyInstanceId));
     }
+
+    public void navigateToLocationSettings(Context context) {
+         context.startActivity(new Intent("android.settings.LOCATION_SOURCE_SETTINGS"));
+    }
 }

--- a/app/src/main/java/org/akvo/flow/ui/fragment/GpsDisabledDialogFragment.java
+++ b/app/src/main/java/org/akvo/flow/ui/fragment/GpsDisabledDialogFragment.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.akvo.flow.ui.fragment;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
+
+import org.akvo.flow.R;
+import org.akvo.flow.ui.Navigator;
+
+public class GpsDisabledDialogFragment extends DialogFragment {
+
+    public static final String GPS_DIALOG_TAG = "gps_dialog";
+
+    private final Navigator navigator = new Navigator();
+
+    public static GpsDisabledDialogFragment newInstance() {
+        GpsDisabledDialogFragment frag = new GpsDisabledDialogFragment();
+        return frag;
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        return new AlertDialog.Builder(getActivity()).setMessage(R.string.geodialog)
+                .setCancelable(true)
+                .setPositiveButton(R.string.okbutton,
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int id) {
+                                navigator.navigateToLocationSettings(getActivity());
+                            }
+                        })
+                .setNegativeButton(R.string.cancelbutton,
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int id) {
+                                dialog.cancel();
+                            }
+                        }).create();
+    }
+}

--- a/app/src/main/java/org/akvo/flow/ui/view/GeoQuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/GeoQuestionView.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2017 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo Flow.
  *
@@ -22,6 +22,9 @@ package org.akvo.flow.ui.view;
 import android.content.Context;
 import android.graphics.Color;
 import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -35,8 +38,8 @@ import org.akvo.flow.domain.Question;
 import org.akvo.flow.domain.QuestionResponse;
 import org.akvo.flow.event.SurveyListener;
 import org.akvo.flow.event.TimedLocationListener;
+import org.akvo.flow.ui.fragment.GpsDisabledDialogFragment;
 import org.akvo.flow.util.ConstantUtil;
-import org.akvo.flow.util.ViewUtil;
 
 import java.text.DecimalFormat;
 
@@ -202,7 +205,13 @@ public class GeoQuestionView extends QuestionView implements OnClickListener, On
     @Override
     public void onGPSDisabled() {
         // we can't turn GPS on directly, the best we can do is launch the settings page
-        ViewUtil.showGPSDialog(getContext());
+        Context context = getContext();
+        if (context instanceof AppCompatActivity) {
+            FragmentManager fragmentManager = ((AppCompatActivity) context)
+                    .getSupportFragmentManager();
+            DialogFragment newFragment = GpsDisabledDialogFragment.newInstance();
+            newFragment.show(fragmentManager, GpsDisabledDialogFragment.GPS_DIALOG_TAG);
+        }
     }
 
     /**

--- a/app/src/main/java/org/akvo/flow/util/ViewUtil.java
+++ b/app/src/main/java/org/akvo/flow/util/ViewUtil.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2017 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo Flow.
  *
@@ -22,7 +22,6 @@ package org.akvo.flow.util;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.Intent;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.view.ViewGroup.LayoutParams;
@@ -38,35 +37,6 @@ import org.akvo.flow.service.ServiceToastRunnable;
  * @author Christopher Fagiani
  */
 public class ViewUtil {
-
-    /**
-     * displays the alert dialog box warning that the GPS receiver is off. If
-     * the affirmative button is clicked, the Location Settings panel is
-     * launched. If the negative button is clicked, it will just close the
-     * dialog
-     *
-     * @param parentContext
-     */
-    public static void showGPSDialog(final Context parentContext) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(parentContext);
-        builder.setMessage(R.string.geodialog)
-                .setCancelable(true)
-                .setPositiveButton(R.string.okbutton,
-                        new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int id) {
-                                parentContext
-                                        .startActivity(new Intent(
-                                                "android.settings.LOCATION_SOURCE_SETTINGS"));
-                            }
-                        })
-                .setNegativeButton(R.string.cancelbutton,
-                        new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int id) {
-                                dialog.cancel();
-                            }
-                        });
-        builder.show();
-    }
 
     /**
      * displays a simple dialog box with only a single, positive button using


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
There is a crash when we attempt to add a dialog and the activity is being destroyed (due to device rotation).
#### The solution
The solution is to use DialogFragments instead which handle better activity lifecycle
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
