### PR TITLE
Fix date picker wrong formatting (connect #662)

### DIFF
--- a/app/src/main/java/org/akvo/flow/ui/view/DateQuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/DateQuestionView.java
@@ -122,12 +122,14 @@ public class DateQuestionView extends QuestionView implements View.OnClickListen
 
     @Nullable
     private Long parseTimeStampFromResponse(@Nullable QuestionResponse resp) {
-        String value = resp.getValue();
         Long timeStamp = null;
-        try {
-            timeStamp = Long.parseLong(value);
-        } catch (NumberFormatException e) {
-            Timber.e(e, "parseTimeStampFromResponse - Value is not a number: %s", value);
+        if (resp != null) {
+            String value = resp.getValue();
+            try {
+                timeStamp = Long.parseLong(value);
+            } catch (NumberFormatException e) {
+                Timber.e(e, "parseTimeStampFromResponse - Value is not a number: %s", value);
+            }
         }
 
         return timeStamp;

--- a/app/src/main/java/org/akvo/flow/ui/view/DateQuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/DateQuestionView.java
@@ -37,7 +37,6 @@ import org.akvo.flow.util.ConstantUtil;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -63,7 +62,7 @@ public class DateQuestionView extends QuestionView implements View.OnClickListen
     public DateQuestionView(Context context, Question q, SurveyListener surveyListener) {
         super(context, q, surveyListener);
         mLocalCalendar = GregorianCalendar.getInstance(Locale.getDefault());
-        mLocalCalendar.setTime(new Date());
+        mLocalCalendar.setTimeInMillis(System.currentTimeMillis());
         userDisplayedDateFormat = SimpleDateFormat.getDateInstance();
         userDisplayedDateFormat.setTimeZone(TimeZone.getDefault());
         init();


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
The date was displayed correctly in the picker but once saved to database then it was displayed incorrectly in timezones which are far away from GMT.
#### The solution
Making sure to use time stamp and set calendar with time stamp without using Date.
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
