### PR TITLE
Displaying caddisfly results in detail (connect #470)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,6 +97,7 @@ android.applicationVariants.all { variant ->
 dependencies {
     compile fileTree(include: '*.jar', dir: 'libs')
     compile 'com.android.support:appcompat-v7:25.0.1'
+    compile 'com.android.support:recyclerview-v7:25.0.1'
     compile 'com.android.support:support-annotations:25.0.1'
     compile 'com.google.android.gms:play-services-base:7.5.0'
     compile 'com.google.android.gms:play-services-maps:7.5.0'

--- a/app/src/androidTest/java/org/akvo/flow/ui/view/CaddisflyQuestionViewTest.java
+++ b/app/src/androidTest/java/org/akvo/flow/ui/view/CaddisflyQuestionViewTest.java
@@ -9,6 +9,8 @@ import org.mockito.Mockito;
 
 public class CaddisflyQuestionViewTest extends AndroidTestCase {
 
+    public static final String TEST_JSON_RESPONSE = "{\"testDate\":\"2017-01-16 18:13\",\"app\":{\"appVersion\":\"Version 1.0.0 Alpha 7.2\",\"language\":\"en\"},\"result\":[{\"value\":\"650\",\"id\":1,\"unit\":\"μS\\/cm\",\"name\":\"Electrical Conductivity\"},{\"value\":\"19.6\",\"id\":2,\"unit\":\"°Celsius\",\"name\":\"Temperature\"}],\"name\":\"Electrical Conductivity\",\"device\":{\"product\":\"WW_zc451cg\",\"os\":\"Android - 4.4.2 (19)\",\"model\":\"ASUS_Z007\",\"language\":\"en\",\"manufacturer\":\"asus\",\"country\":\"US\"},\"uuid\":\"f88237b7-be3d-4fac-bbee-ab328eefcd14\",\"type\":\"caddisfly\",\"user\":{\"backDropDetection\":true,\"language\":\"en\"}}";
+
     public void testResponse() {
         System.setProperty("dexmaker.dexcache", getContext().getCacheDir().getPath());
 
@@ -18,12 +20,12 @@ public class CaddisflyQuestionViewTest extends AndroidTestCase {
         CaddisflyQuestionView qv = new CaddisflyQuestionView(getContext(), q, l);
 
         Bundle bundle = new Bundle();
-        bundle.putString("response", "response value");
+        bundle.putString("response", TEST_JSON_RESPONSE);
         bundle.putString("image", "nonexistent image");
 
         qv.questionComplete(bundle);
 
-        assertEquals("response value", qv.getResponse().getValue());
+        assertEquals(TEST_JSON_RESPONSE, qv.getResponse().getValue());
         assertNull(qv.getResponse().getFilename());
     }
 }

--- a/app/src/main/java/org/akvo/flow/ui/adapter/CaddisflyResultsAdapter.java
+++ b/app/src/main/java/org/akvo/flow/ui/adapter/CaddisflyResultsAdapter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2017 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.akvo.flow.ui.adapter;
+
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import org.akvo.flow.R;
+import org.akvo.flow.ui.model.caddisfly.CaddisflyTestResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CaddisflyResultsAdapter extends RecyclerView.Adapter<CaddisflyResultsAdapter.ViewHolder> {
+
+    private final ArrayList<CaddisflyTestResult> caddisflyTestResults;
+
+    public CaddisflyResultsAdapter(ArrayList<CaddisflyTestResult> caddisflyTestResults) {
+        this.caddisflyTestResults = caddisflyTestResults;
+    }
+
+    @Override
+    public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        TextView textView = (TextView) LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.caddisfly_question_view_result_item, parent, false);
+        return new ViewHolder(textView);
+    }
+
+    @Override
+    public void onBindViewHolder(ViewHolder holder, int position) {
+        holder.setTextView(caddisflyTestResults.get(position));
+    }
+
+    public void setCaddisflyTestResults(@NonNull List<CaddisflyTestResult> results) {
+        if (results.size() > 0) {
+            caddisflyTestResults.clear();
+            caddisflyTestResults.addAll(results);
+            int size = results.size();
+            notifyItemRangeChanged(0, size);
+        } else {
+            int size = caddisflyTestResults.size();
+            if (size > 0) {
+                caddisflyTestResults.clear();
+                notifyItemRangeRemoved(0, size);
+            }
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        return caddisflyTestResults.size();
+    }
+
+    static class ViewHolder extends RecyclerView.ViewHolder {
+
+        private final TextView textView;
+
+        ViewHolder(TextView itemView) {
+            super(itemView);
+            this.textView = itemView;
+        }
+
+        void setTextView(CaddisflyTestResult result) {
+            if (result != null) {
+                textView.setText(result.buildResultToDisplay());
+            }
+        }
+
+    }
+}

--- a/app/src/main/java/org/akvo/flow/ui/model/caddisfly/CaddisflyJsonMapper.java
+++ b/app/src/main/java/org/akvo/flow/ui/model/caddisfly/CaddisflyJsonMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.akvo.flow.ui.model.caddisfly;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.google.gson.Gson;
+
+import java.util.Collections;
+import java.util.List;
+
+public class CaddisflyJsonMapper {
+
+    private final Gson gson = new Gson();
+
+    public CaddisflyJsonMapper() {
+    }
+
+    @NonNull
+    public List<CaddisflyTestResult> transform(@Nullable String result) {
+        if (result != null) {
+            CaddisflyResult caddisflyResult = gson.fromJson(result, CaddisflyResult.class);
+            if (caddisflyResult != null && caddisflyResult.getResults() != null) {
+                return caddisflyResult.getResults();
+            }
+        }
+        return Collections.emptyList();
+    }
+}

--- a/app/src/main/java/org/akvo/flow/ui/model/caddisfly/CaddisflyResult.java
+++ b/app/src/main/java/org/akvo/flow/ui/model/caddisfly/CaddisflyResult.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2017 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.akvo.flow.ui.model.caddisfly;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+class CaddisflyResult {
+
+    @SerializedName("result")
+    private List<CaddisflyTestResult> results;
+
+    public CaddisflyResult(List<CaddisflyTestResult> results) {
+        this.results = results;
+    }
+
+    public List<CaddisflyTestResult> getResults() {
+        return results;
+    }
+
+    public void setResults(List<CaddisflyTestResult> results) {
+        this.results = results;
+    }
+}

--- a/app/src/main/java/org/akvo/flow/ui/model/caddisfly/CaddisflyTestResult.java
+++ b/app/src/main/java/org/akvo/flow/ui/model/caddisfly/CaddisflyTestResult.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2017 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.akvo.flow.ui.model.caddisfly;
+
+public class CaddisflyTestResult {
+
+    private int id;
+    private String name;
+    private String value;
+    private String unit;
+
+    public CaddisflyTestResult(int id, String name, String value, String unit) {
+        this.id = id;
+        this.name = name;
+        this.value = value;
+        this.unit = unit;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+
+    public String buildResultToDisplay() {
+        String stringBuilder = name +
+                ": " +
+                value +
+                " " +
+                unit;
+        return stringBuilder;
+    }
+}

--- a/app/src/main/java/org/akvo/flow/ui/view/CaddisflyQuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/CaddisflyQuestionView.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2016 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2016-2017 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo Flow.
  *

--- a/app/src/main/java/org/akvo/flow/ui/view/CaddisflyQuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/CaddisflyQuestionView.java
@@ -21,6 +21,8 @@ package org.akvo.flow.ui.view;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.Button;
@@ -31,19 +33,26 @@ import org.akvo.flow.domain.Question;
 import org.akvo.flow.domain.QuestionResponse;
 import org.akvo.flow.event.QuestionInteractionEvent;
 import org.akvo.flow.event.SurveyListener;
+import org.akvo.flow.ui.adapter.CaddisflyResultsAdapter;
+import org.akvo.flow.ui.model.caddisfly.CaddisflyJsonMapper;
+import org.akvo.flow.ui.model.caddisfly.CaddisflyTestResult;
 import org.akvo.flow.util.ConstantUtil;
 import org.akvo.flow.util.FileUtil;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import timber.log.Timber;
 
 public class CaddisflyQuestionView extends QuestionView implements View.OnClickListener {
 
     private Button mButton;
-    private View mResponseView;
     private String mValue;
     private String mImage;
+    private final CaddisflyJsonMapper caddisflyJsonMapper = new CaddisflyJsonMapper();
+    private CaddisflyResultsAdapter caddisflyResultsAdapter;
+    private List<CaddisflyTestResult> caddisflyTestResults = new ArrayList<>();
 
     public CaddisflyQuestionView(Context context, Question q, SurveyListener surveyListener) {
         super(context, q, surveyListener);
@@ -52,14 +61,18 @@ public class CaddisflyQuestionView extends QuestionView implements View.OnClickL
 
     private void init() {
         setQuestionView(R.layout.caddisfly_question_view);
-        mResponseView = findViewById(R.id.response_view);
-        mButton = (Button)findViewById(R.id.button);
+        RecyclerView resultsRv = (RecyclerView) findViewById(R.id.results_recycler_view);
+        resultsRv.setLayoutManager(new LinearLayoutManager(resultsRv.getContext()));
+        caddisflyResultsAdapter = new CaddisflyResultsAdapter(
+                new ArrayList<CaddisflyTestResult>());
+        resultsRv.setAdapter(caddisflyResultsAdapter);
+        mButton = (Button) findViewById(R.id.button);
         mButton.setOnClickListener(this);
         displayResponseView();
     }
 
     private void displayResponseView() {
-        mResponseView.setVisibility(TextUtils.isEmpty(mValue) ? GONE : VISIBLE);
+        caddisflyResultsAdapter.setCaddisflyTestResults(caddisflyTestResults);
         mButton.setEnabled(!mSurveyListener.isReadOnly());
     }
 
@@ -75,6 +88,7 @@ public class CaddisflyQuestionView extends QuestionView implements View.OnClickL
     public void rehydrate(QuestionResponse resp) {
         super.rehydrate(resp);
         mValue = resp != null ? resp.getValue() : null;
+        caddisflyTestResults = caddisflyJsonMapper.transform(mValue);
         displayResponseView();
     }
 
@@ -82,6 +96,7 @@ public class CaddisflyQuestionView extends QuestionView implements View.OnClickL
     public void resetQuestion(boolean fireEvent) {
         super.resetQuestion(fireEvent);
         mValue = null;
+        caddisflyTestResults = caddisflyJsonMapper.transform(mValue);
         displayResponseView();
     }
 
@@ -89,11 +104,11 @@ public class CaddisflyQuestionView extends QuestionView implements View.OnClickL
     public void questionComplete(Bundle data) {
         if (data != null) {
             mValue = data.getString(ConstantUtil.CADDISFLY_RESPONSE);
-
+            caddisflyTestResults = caddisflyJsonMapper.transform(mValue);
             // Get optional image and store it as part of the response
             String image = data.getString(ConstantUtil.CADDISFLY_IMAGE);
 
-            Timber.d("caddisflyTestComplete - Response: " + mValue + ". Image: " + image);
+            Timber.d("caddisflyTestComplete - Response: %s . Image: %s", mValue, image);
 
             File src = !TextUtils.isEmpty(image) ? new File(image) : null;
             if (src != null && src.exists()) {
@@ -101,8 +116,8 @@ public class CaddisflyQuestionView extends QuestionView implements View.OnClickL
                 File dst = new File(FileUtil.getFilesDir(FileUtil.FileType.MEDIA), src.getName());
 
                 if (!src.renameTo(dst)) {
-                    Timber.e(String.format("Could not move file %s to %s",
-                            src.getAbsoluteFile(), dst.getAbsoluteFile()));
+                    Timber.e("Could not move file %s to %s", src.getAbsoluteFile(),
+                            dst.getAbsoluteFile());
                 } else {
                     mImage = dst.getAbsolutePath();
                 }

--- a/app/src/main/res/layout/caddisfly_question_view.xml
+++ b/app/src/main/res/layout/caddisfly_question_view.xml
@@ -4,33 +4,13 @@
 
     <include layout="@layout/question_header" />
 
-    <RelativeLayout
-        android:id="@+id/response_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <ImageView
-            android:id="@+id/checkmark"
-            android:layout_width="30dp"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_centerVertical="true"
-            android:adjustViewBounds="true"
-            android:src="@drawable/checkmark" />
-
-        <TextView
+    <android.support.v7.widget.RecyclerView
+            android:id="@+id/results_recycler_view"
+            android:scrollbars="none"
+            android:layout_marginTop="2dp"
+            android:layout_marginBottom="4dp"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_centerVertical="true"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:layout_toEndOf="@id/checkmark"
-            android:layout_toRightOf="@id/checkmark"
-            android:text="@string/caddisfly_response"
-            android:textColor="#8dc63f"
-            android:textSize="18sp" />
-    </RelativeLayout>
+            android:layout_height="wrap_content" />
 
     <Button
         android:id="@+id/button"

--- a/app/src/main/res/layout/caddisfly_question_view_result_item.xml
+++ b/app/src/main/res/layout/caddisfly_question_view_result_item.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+          android:id="@+id/result_text_view"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content">
+</TextView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,7 +149,6 @@
     <string name="error_img_preview">Can\'t load image preview</string>
     <string name="use_external_source">Use External Source</string>
     <string name="caddisfly_test">Go to test</string>
-    <string name="caddisfly_response">Test captured successfully</string>
     <string name="error_empty_form">Empty forms cannot be submitted. Please, add the corresponding responses first.</string>
     <string name="select">please select</string>
     <string name="clear_value_msg">Do you want to delete this value?</string>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Caddisfly responses are not displayed. Only "test captured successfully" is displayed
#### The solution
Displaying captured results by parsing the json string.
#### Screenshots (if appropriate)
![screenshot_20170322-173631](https://cloud.githubusercontent.com/assets/923280/24241422/14238356-0fb5-11e7-9ac2-66f5c2a22d52.png)

#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
