### PR TITLE
Location setting dialog message (connect #672)

### DIFF
--- a/app/src/main/java/org/akvo/flow/ui/Navigator.java
+++ b/app/src/main/java/org/akvo/flow/ui/Navigator.java
@@ -182,7 +182,6 @@ public class Navigator {
 
     /**
      * Fallback as Settings.ACTION_LOCATION_SOURCE_SETTINGS may not be available on some devices
-     * @param context
      */
     private void navigateToSettings(@NonNull Context context) {
         context.startActivity(new Intent(Settings.ACTION_SETTINGS));

--- a/app/src/main/java/org/akvo/flow/ui/Navigator.java
+++ b/app/src/main/java/org/akvo/flow/ui/Navigator.java
@@ -24,8 +24,10 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
@@ -168,7 +170,21 @@ public class Navigator {
                 .putExtra(ConstantUtil.RESPONDENT_ID_KEY, surveyInstanceId));
     }
 
-    public void navigateToLocationSettings(Context context) {
-         context.startActivity(new Intent("android.settings.LOCATION_SOURCE_SETTINGS"));
+    public void navigateToLocationSettings(@NonNull Context context) {
+        Intent intent = new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS);
+        PackageManager packageManager = context.getPackageManager();
+        if (intent.resolveActivity(packageManager) != null) {
+            context.startActivity(intent);
+        } else {
+            navigateToSettings(context);
+        }
+    }
+
+    /**
+     * Fallback as Settings.ACTION_LOCATION_SOURCE_SETTINGS may not be available on some devices
+     * @param context
+     */
+    private void navigateToSettings(@NonNull Context context) {
+        context.startActivity(new Intent(Settings.ACTION_SETTINGS));
     }
 }

--- a/app/src/main/java/org/akvo/flow/ui/fragment/GpsDisabledDialogFragment.java
+++ b/app/src/main/java/org/akvo/flow/ui/fragment/GpsDisabledDialogFragment.java
@@ -42,9 +42,9 @@ public class GpsDisabledDialogFragment extends DialogFragment {
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        return new AlertDialog.Builder(getActivity()).setMessage(R.string.geodialog)
+        return new AlertDialog.Builder(getActivity()).setTitle(R.string.geodialog)
                 .setCancelable(true)
-                .setPositiveButton(R.string.okbutton,
+                .setPositiveButton(R.string.settings,
                         new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int id) {
                                 navigator.navigateToLocationSettings(getActivity());

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,7 +13,8 @@
     <string name="lon">Lon</string>
     <string name="elevation">Height</string>
     <string name="submitbutton">Submit</string>
-    <string name="geodialog">GPS must be enabled to do this. Select OK to go to the settings page. Select Use GPS Satellites and then press the back button to return. Once GPS is enabled you can click Check Geo Location again to get your position.</string>
+    <string name="geodialog">Please enable location settings</string>
+    <string name="settings">Settings</string>
     <string name="resize_large_images">Resize large images</string>
     <string name="settingslabel">Settings</string>
     <string name="nouser">No Users!</string>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When gps is disabled we display a dialog to prompt user to go to location setting and enable location. That dialog had e very long and complicated text.
#### The solution
Simplify the text.
Extra bonus added check if that intent exists and if it does not, just take the user to general settings screen.
#### Screenshots (if appropriate)
![screenshot_1490709886](https://cloud.githubusercontent.com/assets/923280/24457282/05a8c6ca-1496-11e7-8db6-4b82c913d438.png)

#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
