### PR TITLE
Disabling manual input fields while getting automatic location

### DIFF
--- a/app/src/main/java/org/akvo/flow/ui/view/GeoInputContainer.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/GeoInputContainer.java
@@ -124,12 +124,26 @@ public class GeoInputContainer extends LinearLayout {
 
     void showLocationListenerStopped() {
         setAlpha(ALPHA_TRANSPARENT, ALPHA_OPAQUE);
+        enableManualInput();
+    }
+
+    private void enableManualInput() {
+        latitudeInput.setEnabled(true);
+        longitudeInput.setEnabled(true);
+        elevationInput.setEnabled(true);
     }
 
     void showLocationListenerStarted() {
         setAlpha(ALPHA_OPAQUE, ALPHA_TRANSPARENT);
         resetChildViewsToDefaultValues();
         showCoordinatesInaccurate();
+        disableManualInput();
+    }
+
+    private void disableManualInput() {
+        latitudeInput.setEnabled(false);
+        longitudeInput.setEnabled(false);
+        elevationInput.setEnabled(false);
     }
 
     private void showCoordinatesInaccurate() {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
GeoQuestionView: manual input is still possible while waiting for device location
#### The solution
disabling edit texts when we start getting automatic location, re-enabling if cancelled/timeout/completed
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
