### PR TITLE
Record activity still shows deleted entry (connect #742)

### DIFF
--- a/app/src/main/java/org/akvo/flow/activity/FormActivity.java
+++ b/app/src/main/java/org/akvo/flow/activity/FormActivity.java
@@ -297,7 +297,22 @@ public class FormActivity extends BackActivity implements SurveyListener,
     }
 
     private void saveRecordMetaData() {
-        // META_NAME
+        saveRecordName();
+        saveRecordLocation();
+    }
+
+    private void saveRecordLocation() {
+        String localeGeoQuestion = mSurvey.getLocaleGeoQuestion();
+        if (localeGeoQuestion != null) {
+            QuestionResponse response = mDatabase.getResponse(mSurveyInstanceId, localeGeoQuestion);
+            if (response != null) {
+                mDatabase.updateSurveyedLocale(mSurveyInstanceId, response.getValue(),
+                        SurveyedLocaleMeta.GEOLOCATION);
+            }
+        }
+    }
+
+    private void saveRecordName() {
         StringBuilder builder = new StringBuilder();
         List<String> localeNameQuestions = mSurvey.getLocaleNameQuestions();
 
@@ -325,16 +340,18 @@ public class FormActivity extends BackActivity implements SurveyListener,
             mDatabase.updateSurveyedLocale(mSurveyInstanceId, builder.toString(),
                     SurveyedLocaleMeta.NAME);
         }
+    }
 
-        // META_GEO
-        String localeGeoQuestion = mSurvey.getLocaleGeoQuestion();
-        if (localeGeoQuestion != null) {
-            QuestionResponse response = mDatabase.getResponse(mSurveyInstanceId, localeGeoQuestion);
-            if (response != null) {
-                mDatabase.updateSurveyedLocale(mSurveyInstanceId, response.getValue(),
-                        SurveyedLocaleMeta.GEOLOCATION);
-            }
+    private void resetRecordName() {
+        if (!mSurveyGroup.isMonitored() || isRegistrationForm()) {
+            mDatabase.clearSurveyedLocaleName(mSurveyInstanceId);
         }
+    }
+
+    private boolean isRegistrationForm() {
+        Survey registrationForm = mDatabase.getRegistrationForm(mSurveyGroup);
+        return registrationForm != null && registrationForm.getId() != null && registrationForm
+                .getId().equals(surveyId);
     }
 
     @Override
@@ -413,6 +430,7 @@ public class FormActivity extends BackActivity implements SurveyListener,
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         mDatabase.deleteResponses(String.valueOf(mSurveyInstanceId));
+                        resetRecordName();
                         loadResponses();
                         spaceLeftOnCard();
                     }

--- a/app/src/main/java/org/akvo/flow/activity/FormActivity.java
+++ b/app/src/main/java/org/akvo/flow/activity/FormActivity.java
@@ -289,8 +289,8 @@ public class FormActivity extends BackActivity implements SurveyListener,
             mDatabase.updateRecordModifiedDate(mRecordId, System.currentTimeMillis());
 
             // Record meta-data, if applies
-            if (!mSurveyGroup.isMonitored() ||
-                    mSurvey.getId().equals(mSurveyGroup.getRegisterSurveyId())) {
+            if (!mSurveyGroup.isMonitored() || mSurvey.getId()
+                    .equals(mSurveyGroup.getRegisterSurveyId())) {
                 saveRecordMetaData();
             }
         }

--- a/app/src/main/java/org/akvo/flow/activity/RecordActivity.java
+++ b/app/src/main/java/org/akvo/flow/activity/RecordActivity.java
@@ -41,11 +41,13 @@ import org.akvo.flow.service.BootstrapService;
 import org.akvo.flow.ui.Navigator;
 import org.akvo.flow.ui.adapter.RecordTabsAdapter;
 import org.akvo.flow.ui.fragment.FormListFragment.SurveyListListener;
+import org.akvo.flow.ui.fragment.ResponseListFragment;
 import org.akvo.flow.util.ConstantUtil;
 
 import javax.inject.Inject;
 
-public class RecordActivity extends BackActivity implements SurveyListListener {
+public class RecordActivity extends BackActivity implements SurveyListListener,
+        ResponseListFragment.ResponseListListener {
 
     private static final int REQUEST_FORM = 0;
 
@@ -70,8 +72,6 @@ public class RecordActivity extends BackActivity implements SurveyListListener {
 
         mSurveyGroup = (SurveyGroup) getIntent().getSerializableExtra(
                 ConstantUtil.SURVEY_GROUP_EXTRA);
-        setTitle(mSurveyGroup.getName());
-
         setupToolBar();
     }
 
@@ -92,15 +92,18 @@ public class RecordActivity extends BackActivity implements SurveyListListener {
         mDatabase.open();
 
         mUser = FlowApp.getApp().getUser();
+
+        updateRecordTitle();
+    }
+
+    private void updateRecordTitle() {
         // Record might have changed while answering a registration survey
         String recordId = getIntent().getStringExtra(ConstantUtil.RECORD_ID_EXTRA);
         mRecord = mDatabase.getSurveyedLocale(recordId);
-        displayRecord();
-    }
-
-    private void displayRecord() {
         if (mRecord != null) {
             setTitle(mRecord.getDisplayName(this));
+        } else {
+            setTitle(getString(R.string.unknown));
         }
     }
 
@@ -144,6 +147,11 @@ public class RecordActivity extends BackActivity implements SurveyListListener {
 
     private String getRecordId() {
         return mRecord == null ? "" : mRecord.getId();
+    }
+
+    @Override
+    public void onNamedRecordDeleted() {
+        updateRecordTitle();
     }
 
     // ==================================== //

--- a/app/src/main/java/org/akvo/flow/data/database/SurveyDbAdapter.java
+++ b/app/src/main/java/org/akvo/flow/data/database/SurveyDbAdapter.java
@@ -820,7 +820,7 @@ public class SurveyDbAdapter {
     public SurveyedLocale getSurveyedLocale(String surveyedLocaleId) {
         Cursor cursor = database.query(Tables.RECORD, RecordQuery.PROJECTION,
                 RecordColumns.RECORD_ID + " = ?",
-                new String[] { String.valueOf(surveyedLocaleId) },
+                new String[] { surveyedLocaleId },
                 null, null, null);
 
         SurveyedLocale locale = null;
@@ -1057,6 +1057,15 @@ public class SurveyDbAdapter {
         }
         cursor.close();
         return id;
+    }
+
+    public void clearSurveyedLocaleName(long surveyInstanceId) {
+        String surveyedLocaleId = getSurveyedLocaleId(surveyInstanceId);
+        ContentValues surveyedLocaleValues = new ContentValues();
+        surveyedLocaleValues.put(RecordColumns.NAME, "");
+        database.update(Tables.RECORD, surveyedLocaleValues,
+                RecordColumns.RECORD_ID + " = ?",
+                new String[] { surveyedLocaleId });
     }
 
     /**

--- a/app/src/main/java/org/akvo/flow/data/database/SurveyDbAdapter.java
+++ b/app/src/main/java/org/akvo/flow/data/database/SurveyDbAdapter.java
@@ -65,8 +65,13 @@ public class SurveyDbAdapter {
     private static final String SURVEY_INSTANCE_JOIN_SURVEY = "survey_instance "
             + "JOIN survey ON survey_instance.survey_id = survey.survey_id "
             + "JOIN survey_group ON survey.survey_group_id=survey_group.survey_group_id";
+    private static final String SURVEY_INSTANCE_JOIN_SURVEY_AND_RESPONSE = "survey_instance "
+            + "JOIN survey ON survey_instance.survey_id = survey.survey_id "
+            + "JOIN survey_group ON survey.survey_group_id=survey_group.survey_group_id "
+            + "JOIN response ON survey_instance._id=response.survey_instance_id";
 
-    public static final String SURVEY_JOIN_SURVEY_INSTANCE = "survey LEFT OUTER JOIN survey_instance ON "
+    public static final String SURVEY_JOIN_SURVEY_INSTANCE =
+            "survey LEFT OUTER JOIN survey_instance ON "
             + "survey.survey_id=survey_instance.survey_id";
 
     private static final int DOES_NOT_EXIST = -1;
@@ -958,6 +963,21 @@ public class SurveyDbAdapter {
                 Tables.SURVEY_INSTANCE + "." + SurveyInstanceColumns.RECORD_ID + "= ?",
                 new String[] { recordId },
                 null, null,
+                "CASE WHEN survey.survey_id = survey_group.register_survey_id THEN 0 ELSE 1 END, "
+                        + SurveyInstanceColumns.START_DATE + " DESC");
+    }
+
+    /**
+     * Get all the SurveyInstances for a particular data point which actually have non empty
+     * responses. Registration form will be at the top of the list, all other forms will be ordered
+     * by submission date (desc).
+     */
+    public Cursor getFormInstancesWithResponses(String recordId) {
+        return database.query(SURVEY_INSTANCE_JOIN_SURVEY_AND_RESPONSE,
+                FormInstanceQuery.PROJECTION,
+                Tables.SURVEY_INSTANCE + "." + SurveyInstanceColumns.RECORD_ID + "= ?",
+                new String[] { recordId },
+                ResponseColumns.SURVEY_INSTANCE_ID, null,
                 "CASE WHEN survey.survey_id = survey_group.register_survey_id THEN 0 ELSE 1 END, "
                         + SurveyInstanceColumns.START_DATE + " DESC");
     }

--- a/app/src/main/java/org/akvo/flow/data/database/SurveyDbAdapter.java
+++ b/app/src/main/java/org/akvo/flow/data/database/SurveyDbAdapter.java
@@ -820,7 +820,7 @@ public class SurveyDbAdapter {
     public SurveyedLocale getSurveyedLocale(String surveyedLocaleId) {
         Cursor cursor = database.query(Tables.RECORD, RecordQuery.PROJECTION,
                 RecordColumns.RECORD_ID + " = ?",
-                new String[] { surveyedLocaleId },
+                new String[] {surveyedLocaleId},
                 null, null, null);
 
         SurveyedLocale locale = null;

--- a/app/src/main/java/org/akvo/flow/data/loader/SurveyInstanceLoader.java
+++ b/app/src/main/java/org/akvo/flow/data/loader/SurveyInstanceLoader.java
@@ -23,20 +23,24 @@ package org.akvo.flow.data.loader;
 import android.content.Context;
 import android.database.Cursor;
 
-import org.akvo.flow.data.loader.base.DataLoader;
 import org.akvo.flow.data.database.SurveyDbAdapter;
+import org.akvo.flow.data.loader.base.AsyncLoader;
 
-public class SurveyInstanceLoader extends DataLoader<Cursor> {
-    private String mSurveyedLocaleId;
+public class SurveyInstanceLoader extends AsyncLoader<Cursor> {
 
-    public SurveyInstanceLoader(Context context, SurveyDbAdapter db,  String surveyedLocaleId) {
-        super(context, db);
-        mSurveyedLocaleId = surveyedLocaleId;
+    private final String surveyedLocaleId;
+
+    public SurveyInstanceLoader(Context context, String surveyedLocaleId) {
+        super(context);
+        this.surveyedLocaleId = surveyedLocaleId;
     }
 
     @Override
-    public Cursor loadData(SurveyDbAdapter database) {
-        return database.getFormInstances(mSurveyedLocaleId);
+    public Cursor loadInBackground() {
+        SurveyDbAdapter database = new SurveyDbAdapter(getContext().getApplicationContext());
+        database.open();
+        Cursor formInstances = database.getFormInstances(surveyedLocaleId);
+        database.close();
+        return formInstances;
     }
-
 }

--- a/app/src/main/java/org/akvo/flow/data/loader/SurveyInstanceResponseLoader.java
+++ b/app/src/main/java/org/akvo/flow/data/loader/SurveyInstanceResponseLoader.java
@@ -26,11 +26,11 @@ import android.database.Cursor;
 import org.akvo.flow.data.database.SurveyDbAdapter;
 import org.akvo.flow.data.loader.base.AsyncLoader;
 
-public class SurveyInstanceLoader extends AsyncLoader<Cursor> {
+public class SurveyInstanceResponseLoader extends AsyncLoader<Cursor> {
 
     private final String surveyedLocaleId;
 
-    public SurveyInstanceLoader(Context context, String surveyedLocaleId) {
+    public SurveyInstanceResponseLoader(Context context, String surveyedLocaleId) {
         super(context);
         this.surveyedLocaleId = surveyedLocaleId;
     }
@@ -39,7 +39,7 @@ public class SurveyInstanceLoader extends AsyncLoader<Cursor> {
     public Cursor loadInBackground() {
         SurveyDbAdapter database = new SurveyDbAdapter(getContext().getApplicationContext());
         database.open();
-        Cursor formInstances = database.getFormInstances(surveyedLocaleId);
+        Cursor formInstances = database.getFormInstancesWithResponses(surveyedLocaleId);
         database.close();
         return formInstances;
     }

--- a/app/src/main/java/org/akvo/flow/ui/adapter/ResponseListAdapter.java
+++ b/app/src/main/java/org/akvo/flow/ui/adapter/ResponseListAdapter.java
@@ -39,16 +39,20 @@ import java.util.Date;
 
 public class ResponseListAdapter extends CursorAdapter {
 
-    public ResponseListAdapter(Context context) {
-        super(context, null, false);
+    private final int[] backgrounds = new int[2];
+
+    public ResponseListAdapter(Context activityContext) {
+        super(activityContext.getApplicationContext(), null, false);
+        backgrounds[0] = PlatformUtil.getResource(activityContext, R.attr.listitem_bg1);
+        backgrounds[1] = PlatformUtil.getResource(activityContext, R.attr.listitem_bg2);
     }
 
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
         final int status = cursor.getInt(FormInstanceQuery.STATUS);
 
-        // Default to 'Submitted' status values
         int icon = 0;
+        // Default to 'Submitted' status values
         String statusText = context.getString(R.string.status_submitted) + ": ";
         long displayDate = cursor.getLong(FormInstanceQuery.SUBMITTED_DATE);
 
@@ -93,17 +97,15 @@ public class ResponseListAdapter extends CursorAdapter {
         stsIcon.setImageResource(icon);
 
         // Alternate background
-        int attr = cursor.getPosition() % 2 == 0 ? R.attr.listitem_bg1
-                : R.attr.listitem_bg2;
-        final int res= PlatformUtil.getResource(context, attr);
-        view.setBackgroundResource(res);
+        int backgroundIndex = cursor.getPosition() % 2 == 0 ? 0 : 1;
+        view.setBackgroundResource(backgrounds[backgroundIndex]);
     }
 
     @Override
     public View newView(Context context, Cursor cursor, ViewGroup parent) {
-        LayoutInflater inflater = (LayoutInflater) context
+        Context activityContext = parent.getContext();
+        LayoutInflater inflater = (LayoutInflater) activityContext
                 .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         return inflater.inflate(R.layout.submittedrow, parent, false);
     }
-
 }

--- a/app/src/main/java/org/akvo/flow/ui/fragment/ResponseListFragment.java
+++ b/app/src/main/java/org/akvo/flow/ui/fragment/ResponseListFragment.java
@@ -41,7 +41,7 @@ import android.widget.ListView;
 import org.akvo.flow.R;
 import org.akvo.flow.app.FlowApp;
 import org.akvo.flow.data.database.SurveyDbAdapter;
-import org.akvo.flow.data.loader.SurveyInstanceLoader;
+import org.akvo.flow.data.loader.SurveyInstanceResponseLoader;
 import org.akvo.flow.domain.SurveyGroup;
 import org.akvo.flow.injector.component.ApplicationComponent;
 import org.akvo.flow.injector.component.DaggerViewComponent;
@@ -199,7 +199,7 @@ public class  ResponseListFragment extends ListFragment implements LoaderCallbac
 
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
-        return new SurveyInstanceLoader(getActivity(), recordId);
+        return new SurveyInstanceResponseLoader(getActivity(), recordId);
     }
 
     @Override
@@ -213,6 +213,8 @@ public class  ResponseListFragment extends ListFragment implements LoaderCallbac
     }
 
     /**
+     * TODO: make a static inner class to avoid memory leaks
+     *
      * BroadcastReceiver to notify of data synchronisation. This should be
      * fired from DataSyncService.
      */
@@ -223,5 +225,4 @@ public class  ResponseListFragment extends ListFragment implements LoaderCallbac
             refresh();
         }
     };
-
 }

--- a/app/src/main/java/org/akvo/flow/ui/fragment/ResponseListFragment.java
+++ b/app/src/main/java/org/akvo/flow/ui/fragment/ResponseListFragment.java
@@ -174,8 +174,7 @@ public class  ResponseListFragment extends ListFragment implements LoaderCallbac
         switch (item.getItemId()) {
             case DELETE_ONE:
                 View itemView = info.targetView;
-                showConfirmationDialog(surveyInstanceId,
-                        itemView.getTag(ConstantUtil.SURVEY_ID_TAG_KEY) + "");
+                showConfirmationDialog(surveyInstanceId, itemView.getTag(SURVEY_ID_TAG_KEY) + "");
                 break;
             case VIEW_HISTORY:
                 viewSurveyInstanceHistory(surveyInstanceId);


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Clearing the answers but the entry was still being displayed in the list when pressing "back"
#### The solution
Only display response entries which have actual answers and update the activity title to "unknown datapoint" when the named record has been deleted.
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
