### PR TITLE
If a transmission entry already exists, just update its date (connect #737)

### DIFF
--- a/app/src/main/java/org/akvo/flow/data/database/SurveyDbAdapter.java
+++ b/app/src/main/java/org/akvo/flow/data/database/SurveyDbAdapter.java
@@ -1253,7 +1253,7 @@ public class SurveyDbAdapter {
         contentValues.put(TransmissionColumns.START_DATE, date);
         contentValues.put(TransmissionColumns.END_DATE, date);
         database.update(Tables.TRANSMISSION, contentValues, TransmissionColumns._ID + " = ?",
-                new String[] { transmissionID + "" });
+                new String[] {transmissionID + ""});
     }
 
     public void syncSurveyedLocale(SurveyedLocale surveyedLocale) {

--- a/app/src/main/java/org/akvo/flow/data/database/SurveyDbAdapter.java
+++ b/app/src/main/java/org/akvo/flow/data/database/SurveyDbAdapter.java
@@ -1191,9 +1191,9 @@ public class SurveyDbAdapter {
                     new String[] { surveyInstance.getUuid() },
                     null, null, null);
 
-            long id = DOES_NOT_EXIST;
+            long surveyInstanceId = DOES_NOT_EXIST;
             if (cursor.moveToFirst()) {
-                id = cursor.getLong(0);
+                surveyInstanceId = cursor.getLong(0);
             }
             cursor.close();
 
@@ -1205,22 +1205,55 @@ public class SurveyDbAdapter {
             values.put(SurveyInstanceColumns.SYNC_DATE, System.currentTimeMillis());
             values.put(SurveyInstanceColumns.SUBMITTER, surveyInstance.getSubmitter());
 
-            if (id != DOES_NOT_EXIST) {
+            if (surveyInstanceId != DOES_NOT_EXIST) {
                 database.update(Tables.SURVEY_INSTANCE, values, SurveyInstanceColumns.UUID
                         + " = ?", new String[] { surveyInstance.getUuid() });
             } else {
                 values.put(SurveyInstanceColumns.UUID, surveyInstance.getUuid());
-                id = database.insert(Tables.SURVEY_INSTANCE, null, values);
+                surveyInstanceId = database.insert(Tables.SURVEY_INSTANCE, null, values);
             }
 
-            // Now the responses...
-            syncResponses(surveyInstance.getResponses(), id);
+            syncResponses(surveyInstance.getResponses(), surveyInstanceId);
+            updateTransmission(surveyInstance, surveyInstanceId);
+        }
+    }
 
-            // The filename is a unique column in the transmission table, and as we do not have
-            // a file to hold this data, we set the value to the instance UUID
-            createTransmission(id, surveyInstance.getSurveyId(), surveyInstance.getUuid(),
+    private void updateTransmission(SurveyInstance surveyInstance, long surveyInstanceId) {
+        // The filename is a unique column in the transmission table, if we do not have
+        // a file to hold this data, we set the value to the instance UUID
+        Cursor cursor = null;
+        if (surveyInstanceId != DOES_NOT_EXIST) {
+            cursor = database.query(Tables.TRANSMISSION,
+                    new String[] {
+                            TransmissionColumns._ID,
+                    },
+                    TransmissionColumns.SURVEY_INSTANCE_ID + " = ? ",
+                    new String[] { String.valueOf(surveyInstanceId)},
+                    null, null, null);
+        }
+        if (cursor != null && cursor.moveToFirst()) {
+            int columnIndex = cursor.getColumnIndex(TransmissionColumns._ID);
+            do {
+                updateTransmission(cursor.getInt(columnIndex));
+            } while (cursor.moveToNext());
+        } else {
+            createTransmission(surveyInstanceId, surveyInstance.getSurveyId(),
+                    surveyInstance.getUuid(),
                     TransmissionStatus.SYNCED);
         }
+        if (cursor != null) {
+            cursor.close();
+        }
+    }
+
+    private void updateTransmission(int transmissionID) {
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(TransmissionColumns.STATUS, TransmissionStatus.SYNCED);
+        final String date = String.valueOf(System.currentTimeMillis());
+        contentValues.put(TransmissionColumns.START_DATE, date);
+        contentValues.put(TransmissionColumns.END_DATE, date);
+        database.update(Tables.TRANSMISSION, contentValues, TransmissionColumns._ID + " = ?",
+                new String[] { transmissionID + "" });
     }
 
     public void syncSurveyedLocale(SurveyedLocale surveyedLocale) {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When you synced a datapoint created on that same device, the transmission data entry was duplicated.
#### The solution
check if a transmission exists first and update.
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
