### PR TITLE
Prevent survey group from being reset after device rotation (connect #767)

### DIFF
--- a/app/src/main/java/org/akvo/flow/app/FlowApp.java
+++ b/app/src/main/java/org/akvo/flow/app/FlowApp.java
@@ -30,7 +30,6 @@ import org.akvo.flow.R;
 import org.akvo.flow.data.database.SurveyDbAdapter;
 import org.akvo.flow.data.database.UserColumns;
 import org.akvo.flow.data.preference.Prefs;
-import org.akvo.flow.domain.SurveyGroup;
 import org.akvo.flow.domain.User;
 import org.akvo.flow.injector.component.ApplicationComponent;
 import org.akvo.flow.injector.component.DaggerApplicationComponent;
@@ -51,7 +50,6 @@ public class FlowApp extends Application {
     private Locale mLocale;
 
     private User mUser;
-    private long mSurveyGroupId;// Hacky way of filtering the survey group in Record search
     private Prefs prefs;
 
     private ApplicationComponent applicationComponent;
@@ -128,9 +126,6 @@ public class FlowApp extends Application {
         setAppLanguage(language, false);
 
         loadLastUser();
-
-        // Load last survey group
-        mSurveyGroupId = prefs.getLong(Prefs.KEY_SURVEY_GROUP_ID, SurveyGroup.ID_NONE);
     }
 
     public void setUser(User user) {
@@ -140,15 +135,6 @@ public class FlowApp extends Application {
 
     public User getUser() {
         return mUser;
-    }
-
-    public void setSurveyGroupId(long surveyGroupId) {
-        mSurveyGroupId = surveyGroupId;
-        prefs.setLong(Prefs.KEY_SURVEY_GROUP_ID, surveyGroupId);
-    }
-
-    public long getSurveyGroupId() {
-        return mSurveyGroupId;
     }
 
     public String getAppLanguageCode() {

--- a/app/src/main/java/org/akvo/flow/data/DataProvider.java
+++ b/app/src/main/java/org/akvo/flow/data/DataProvider.java
@@ -30,11 +30,14 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import org.akvo.flow.app.FlowApp;
 import org.akvo.flow.data.database.DatabaseHelper;
 import org.akvo.flow.data.database.LanguageTable;
 import org.akvo.flow.data.database.RecordColumns;
 import org.akvo.flow.data.database.Tables;
+import org.akvo.flow.data.preference.Prefs;
+import org.akvo.flow.domain.SurveyGroup;
+
+import static org.akvo.flow.data.preference.Prefs.KEY_SURVEY_GROUP_ID;
 
 public class DataProvider extends ContentProvider {
     
@@ -66,13 +69,14 @@ public class DataProvider extends ContentProvider {
             String sortOrder) {
         // Do the query against a read-only version of the database
         SQLiteDatabase db = mDatabaseHelper.getReadableDatabase();
+        Prefs prefs = new Prefs(getContext().getApplicationContext());
         Cursor cursor = null;
         // Decodes the content URI and maps it to a code
         switch (sUriMatcher.match(uri)) {
             case SEARCH_SUGGEST:
                 // Suggestions search
                 // Adjust incoming query to become SQL text match
-                long surveyGroupId = FlowApp.getApp().getSurveyGroupId();
+                long surveyGroupId = prefs.getLong(KEY_SURVEY_GROUP_ID, SurveyGroup.ID_NONE);
 
                 String nameSearchTerm = createNameSearchTerm(selectionArgs);
                 String idSearchTerm = createIdSearchTerm(selectionArgs);

--- a/app/src/main/java/org/akvo/flow/ui/fragment/DatapointsFragment.java
+++ b/app/src/main/java/org/akvo/flow/ui/fragment/DatapointsFragment.java
@@ -50,6 +50,8 @@ import java.lang.ref.WeakReference;
 import java.util.Map;
 import java.util.WeakHashMap;
 
+import timber.log.Timber;
+
 public class DatapointsFragment extends Fragment {
 
     private static final String TAG = DatapointsFragment.class.getSimpleName();
@@ -99,9 +101,9 @@ public class DatapointsFragment extends Fragment {
         super.onCreate(savedInstanceState);
         mSurveyGroup = (SurveyGroup) getArguments()
                 .getSerializable(ConstantUtil.SURVEY_GROUP_EXTRA);
+        Timber.d("Survey group id is %d", mSurveyGroup.getId());
         tabNames = getResources().getStringArray(R.array.records_activity_tabs);
         setHasOptionsMenu(true);
-        setRetainInstance(true);
     }
 
     @Override
@@ -274,6 +276,7 @@ public class DatapointsFragment extends Fragment {
 
     public void refresh(SurveyGroup surveyGroup) {
         mSurveyGroup = surveyGroup;
+        getArguments().putSerializable(ConstantUtil.SURVEY_GROUP_EXTRA, surveyGroup);
         refreshView();
     }
 

--- a/app/src/main/java/org/akvo/flow/ui/fragment/DatapointsFragment.java
+++ b/app/src/main/java/org/akvo/flow/ui/fragment/DatapointsFragment.java
@@ -50,8 +50,6 @@ import java.lang.ref.WeakReference;
 import java.util.Map;
 import java.util.WeakHashMap;
 
-import timber.log.Timber;
-
 public class DatapointsFragment extends Fragment {
 
     private static final String TAG = DatapointsFragment.class.getSimpleName();
@@ -101,7 +99,6 @@ public class DatapointsFragment extends Fragment {
         super.onCreate(savedInstanceState);
         mSurveyGroup = (SurveyGroup) getArguments()
                 .getSerializable(ConstantUtil.SURVEY_GROUP_EXTRA);
-        Timber.d("Survey group id is %d", mSurveyGroup.getId());
         tabNames = getResources().getStringArray(R.array.records_activity_tabs);
         setHasOptionsMenu(true);
     }

--- a/app/src/main/java/org/akvo/flow/ui/fragment/MapFragment.java
+++ b/app/src/main/java/org/akvo/flow/ui/fragment/MapFragment.java
@@ -241,6 +241,7 @@ public class MapFragment extends SupportMapFragment
 
     public void refresh(SurveyGroup surveyGroup) {
         mSurveyGroup = surveyGroup;
+        getArguments().putSerializable(ConstantUtil.SURVEY_GROUP_EXTRA, surveyGroup);
         refresh();
     }
 

--- a/app/src/main/java/org/akvo/flow/ui/fragment/SurveyedLocaleListFragment.java
+++ b/app/src/main/java/org/akvo/flow/ui/fragment/SurveyedLocaleListFragment.java
@@ -163,6 +163,7 @@ public class SurveyedLocaleListFragment extends ListFragment implements Location
 
     public void refresh(SurveyGroup surveyGroup) {
         mSurveyGroup = surveyGroup;
+        getArguments().putSerializable(ConstantUtil.SURVEY_GROUP_EXTRA, surveyGroup);
         refresh();
     }
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
After rotating the device, the wrong survey is shown
#### The solution
Make sure the correct survey is displayed then device is rotated
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [x] Connect the issue
* [x] Test plan
* [x] Copyright header
* [x] Code formatting
* [x] Documentation
