### PR TITLE
Fixed crash related to snackbar (connect #743)

### DIFF
--- a/app/src/main/java/org/akvo/flow/ui/view/geolocation/GeoQuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/geolocation/GeoQuestionView.java
@@ -27,11 +27,13 @@ import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
+import android.widget.TextView;
 
 import org.akvo.flow.R;
 import org.akvo.flow.domain.Question;
@@ -269,15 +271,24 @@ public class GeoQuestionView extends QuestionView
     @Override
     public void onTimeout() {
         showLocationListenerStopped();
-        Snackbar.make(this, R.string.location_timeout, SNACK_BAR_DURATION_IN_MS)
-                .setAction(R.string.retry, new View.OnClickListener() {
+        View rootView = getRootView().findViewById(R.id.coordinator_layout);
+        Snackbar snackbar = Snackbar
+                .make(rootView, R.string.location_timeout, SNACK_BAR_DURATION_IN_MS)
+                .setAction(R.string.retry, new OnClickListener() {
                     @Override
                     public void onClick(View v) {
                         resetResponseValues();
                         startLocation();
                         showLocationListenerStarted();
                     }
-                }).show();
+                });
+        View snackBarView = snackbar.getView();
+        int snackBarTextId = android.support.design.R.id.snackbar_text;
+        TextView textView = (TextView) snackBarView.findViewById(snackBarTextId);
+        if (textView != null) {
+            textView.setTextColor(ContextCompat.getColor(getContext(), R.color.white));
+        }
+        snackbar.show();
     }
 
     @Override

--- a/app/src/main/res/layout/form_activity.xml
+++ b/app/src/main/res/layout/form_activity.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/coordinator_layout"
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
         xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <dimen name="action_bar_title">14dp</dimen>
-    <dimen name="action_bar_subtitle">10dp</dimen>
-</resources>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
The crash is due tot he fact that the system is attempting to add the snackbar to a ScrollView (not sure why). The ScrollView cannot have more than one child so the app crashes.
#### The solution
Passing the id of the CoordinatorLayout to snackbar directly.
+ set snackbar text color to white (was black on dark background so invisible on some devices)
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [x] Connect the issue
* [x] Test plan
* [x] Copyright header
* [x] Code formatting
* [x] Documentation
