### PR TITLE
Attempt to fix crash in FormActivity (connect #552)

### DIFF
--- a/app/src/main/java/org/akvo/flow/ui/view/geolocation/GeoQuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/geolocation/GeoQuestionView.java
@@ -327,4 +327,11 @@ public class GeoQuestionView extends QuestionView
     public void captureResponse(boolean suppressListeners) {
         saveManualFields();
     }
+
+    @Override
+    public void onDestroy() {
+        if (mLocationListener != null && mLocationListener.isListening()) {
+            mLocationListener.stop();
+        }
+    }
 }


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Hard to reproduce but what happens is the app is trying to close an already opened database. One of the hypothesis is the app has already gone through onDestroy method but at the same time a new location information comes from the listener. 
#### The solution
Stop location updates when activity is destroyed.
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
