### PR TITLE
Fixed styling of error messages (connect #750)

### DIFF
--- a/app/src/main/java/org/akvo/flow/ui/view/ErrorMessageFormatter.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/ErrorMessageFormatter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.akvo.flow.ui.view;
+
+import android.graphics.Color;
+import android.support.annotation.NonNull;
+import android.text.SpannableStringBuilder;
+import android.text.style.ForegroundColorSpan;
+
+public class ErrorMessageFormatter {
+
+    public ErrorMessageFormatter() {
+    }
+
+    @NonNull
+    public SpannableStringBuilder getErrorSpannable(@NonNull String error) {
+        int color = Color.RED;
+        ForegroundColorSpan foregroundColorSpan = new ForegroundColorSpan(color);
+        SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder(error);
+        spannableStringBuilder.setSpan(foregroundColorSpan, 0, error.length(), 0);
+        return spannableStringBuilder;
+    }
+}

--- a/app/src/main/java/org/akvo/flow/ui/view/FreetextQuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/FreetextQuestionView.java
@@ -21,9 +21,11 @@ package org.akvo.flow.ui.view;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.text.Editable;
 import android.text.InputFilter;
 import android.text.InputType;
+import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.text.method.DigitsKeyListener;
@@ -205,12 +207,24 @@ public class FreetextQuestionView extends QuestionView implements View.OnClickLi
         super.resetQuestion(fireEvent);
     }
 
+    /**
+     * Display the error within the EditText (instead of question text)
+     *
+     * @param error Error text
+     */
     @Override
-    public void displayError(String error) {
-        // Display the error within the EditText (instead of question text)
-        mEditText.setError(error);
-        if (isDoubleEntry()) {
-            mDoubleEntryText.setError(error);
+    public void displayError(@Nullable String error) {
+        if (TextUtils.isEmpty(error)) {
+            mEditText.setError(null);
+            if (isDoubleEntry()) {
+                mDoubleEntryText.setError(null);
+            }
+        } else {
+            SpannableStringBuilder errorSpannable = errorMessageFormatter.getErrorSpannable(error);
+            mEditText.setError(errorSpannable);
+            if (isDoubleEntry()) {
+                mDoubleEntryText.setError(errorSpannable);
+            }
         }
     }
 

--- a/app/src/main/java/org/akvo/flow/ui/view/QuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/QuestionView.java
@@ -24,8 +24,10 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.text.Html;
 import android.text.Spanned;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ImageButton;
@@ -54,6 +56,7 @@ import java.util.StringTokenizer;
 public abstract class QuestionView extends LinearLayout implements QuestionInteractionListener {
     private static final int PADDING_DIP = 8;
     protected static String[] sColors = null;
+    final ErrorMessageFormatter errorMessageFormatter = new ErrorMessageFormatter();
 
     protected Question mQuestion;
     private QuestionResponse mResponse;
@@ -319,7 +322,7 @@ public abstract class QuestionView extends LinearLayout implements QuestionInter
      */
     public void addQuestionInteractionListener(QuestionInteractionListener listener) {
         if (mListeners == null) {
-            mListeners = new ArrayList<QuestionInteractionListener>();
+            mListeners = new ArrayList<>();
         }
         if (listener != null && !mListeners.contains(listener) && listener != this) {
             mListeners.add(listener);
@@ -564,8 +567,12 @@ public abstract class QuestionView extends LinearLayout implements QuestionInter
      *
      * @param error Error text
      */
-    public void displayError(String error) {
-        mQuestionText.setError(error);
+    public void displayError(@Nullable String error) {
+        if (TextUtils.isEmpty(error)) {
+            mQuestionText.setError(null);
+        } else {
+            mQuestionText.setError(errorMessageFormatter.getErrorSpannable(error));
+        }
     }
 
     public void checkMandatory() {
@@ -588,7 +595,7 @@ public abstract class QuestionView extends LinearLayout implements QuestionInter
     }
 
     public boolean isDoubleEntry() {
-        return mQuestion != null ? mQuestion.isDoubleEntry() : false;// Avoid NPE
+        return mQuestion != null && mQuestion.isDoubleEntry();
     }
 
     /**

--- a/app/src/main/java/org/akvo/flow/ui/view/geolocation/GeoInputContainer.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/geolocation/GeoInputContainer.java
@@ -27,6 +27,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.text.Editable;
+import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
@@ -37,6 +38,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import org.akvo.flow.R;
+import org.akvo.flow.ui.view.ErrorMessageFormatter;
 import org.akvo.flow.ui.view.ResponseInputWatcher;
 import org.akvo.flow.util.LocationValidator;
 
@@ -50,6 +52,7 @@ public class GeoInputContainer extends LinearLayout {
 
     private final DecimalFormat accuracyFormat = new DecimalFormat("#");
     private final LocationValidator locationValidator = new LocationValidator();
+    private final ErrorMessageFormatter errorMessageFormatter = new ErrorMessageFormatter();
 
     private EditText latitudeInput;
     private EditText longitudeInput;
@@ -124,7 +127,9 @@ public class GeoInputContainer extends LinearLayout {
 
     private void setTextInputError(EditText editText, @StringRes int resId) {
         if (editText != null) {
-            editText.setError(getContext().getString(resId));
+            SpannableStringBuilder errorSpannable = errorMessageFormatter
+                    .getErrorSpannable(getContext().getString(resId));
+            editText.setError(errorSpannable);
         }
     }
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
On android 2.3 the error message was white on white background -> invisible 
On latest android versions the error message is white text on black background
#### The solution
Using spannable to set the error message text color to RED so it will be visible on both white and black backgrounds
#### Screenshots (if appropriate)
![screenshot_2017-07-10_1147](https://user-images.githubusercontent.com/923280/28012262-8760c878-6565-11e7-8cff-a5fd3a8ecdc6.png)
![screenshot_1499679933](https://user-images.githubusercontent.com/923280/28012263-8767f63e-6565-11e7-930b-d36ccf7cfdbc.png)

#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
