### PR TITLE
Fixed user preferences deleted even when not needed (connect #790)

### DIFF
--- a/app/src/main/java/org/akvo/flow/async/ClearDataAsyncTask.java
+++ b/app/src/main/java/org/akvo/flow/async/ClearDataAsyncTask.java
@@ -61,7 +61,9 @@ public class ClearDataAsyncTask extends AsyncTask<Boolean, Void, Boolean> {
 
             // External storage
             clearExternalStorage(responsesOnly);
-            clearUserPreferences();
+            if (!responsesOnly) {
+                clearUserPreferences();
+            }
         } catch (SQLException e) {
             Timber.e(e.getMessage());
             ok = false;


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When pressed delete all collected data we were also deleting the user which is a mistake
#### The solution
Only delete user preferences when "delete everything" is selected
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
