### PR TITLE
Full screen images (connect #989)

### DIFF
--- a/app/src/main/res/layout/activity_full_image.xml
+++ b/app/src/main/res/layout/activity_full_image.xml
@@ -4,6 +4,7 @@
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/black_main"
         tools:context="org.akvo.flow.presentation.FullImageActivity">
 
    <include layout="@layout/app_bar_layout"></include>
@@ -12,7 +13,9 @@
             android:layout_marginTop="?actionBarSize"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scaleType="centerCrop"
+            android:layout_gravity="center"
+            android:scaleType="centerInside"
+            tools:src="@drawable/logo"
             android:id="@+id/imageView"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_full_image.xml
+++ b/app/src/main/res/layout/activity_full_image.xml
@@ -14,7 +14,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_gravity="center"
-            android:scaleType="centerInside"
+            android:scaleType="fitCenter"
             tools:src="@drawable/logo"
             android:id="@+id/imageView"/>
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Images when displayed in full screen mode, were cut off
#### The solution
Display images in full screen correctly both in portrait and landscape
#### Screenshots (if appropriate)
![screenshot_1518776550](https://user-images.githubusercontent.com/923280/36303359-3732dc42-130c-11e8-8e59-d55fc9c8e42d.png)
![screenshot_1518776575](https://user-images.githubusercontent.com/923280/36303368-3ced3150-130c-11e8-85af-d603ea0124cf.png)

#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
