### PR TITLE
Added dexcount tool to always be aware of methods number (connect #1082)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'io.sentry.android.gradle'
+apply plugin: 'com.getkeepsafe.dexcount'
 
 repositories {
     mavenCentral()
@@ -189,6 +190,21 @@ configurations.all { config ->
             }
         }
     }
+}
+
+dexcount {
+    format = "list"
+    includeClasses = false
+    includeClassCount = true
+    includeFieldCount = true
+    includeTotalMethodCount = true
+    orderByMethodCount = true
+    verbose = false
+    maxTreeDepth = Integer.MAX_VALUE
+    teamCityIntegration = false
+    teamCitySlug = null
+    runOnEachPackage = true
+    maxMethodCount = 64000
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'
         classpath 'io.sentry:sentry-android-gradle-plugin:1.5.3'
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.2'
     }
 }
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
We do not check apps method counts and it is easy to be surprised and reach the 65k limit
#### The solution
added a tool to count methods after each build and display results in command line. Example:
after running `./gradlew aFD`
**> Task :app:countFlowDebugDexMethods
Total methods in flow.apk: 56203 (85.76% used)
Total fields in flow.apk:  30862 (47.09% used)
Total classes in flow.apk:  7034 (10.73% used)
Methods remaining in flow.apk: 9332
Fields remaining in flow.apk:  34673
Classes remaining in flow.apk:  58501**
#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
