### PR TITLE
Save build config (connect #1092)

### DIFF
--- a/app/src/main/java/org/akvo/flow/injector/component/ApplicationComponent.java
+++ b/app/src/main/java/org/akvo/flow/injector/component/ApplicationComponent.java
@@ -28,6 +28,7 @@ import org.akvo.flow.app.FlowApp;
 import org.akvo.flow.domain.executor.PostExecutionThread;
 import org.akvo.flow.domain.executor.ThreadExecutor;
 import org.akvo.flow.domain.repository.FileRepository;
+import org.akvo.flow.domain.repository.SetupRepository;
 import org.akvo.flow.domain.repository.SurveyRepository;
 import org.akvo.flow.domain.repository.UserRepository;
 import org.akvo.flow.injector.module.ApplicationModule;
@@ -68,6 +69,8 @@ public interface ApplicationComponent {
     FileRepository fileRepository();
 
     UserRepository userRepository();
+
+    SetupRepository setupRepository();
 
     void inject(FileChangeTrackingService fileChangeTrackingService);
 

--- a/app/src/main/java/org/akvo/flow/injector/module/ApplicationModule.java
+++ b/app/src/main/java/org/akvo/flow/injector/module/ApplicationModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Stichting Akvo (Akvo Foundation)
+ * Copyright (C) 2016-2018 Stichting Akvo (Akvo Foundation)
  *
  * This file is part of Akvo Flow.
  *

--- a/app/src/main/java/org/akvo/flow/injector/module/ApplicationModule.java
+++ b/app/src/main/java/org/akvo/flow/injector/module/ApplicationModule.java
@@ -36,6 +36,7 @@ import org.akvo.flow.data.net.Encoder;
 import org.akvo.flow.data.net.RestServiceFactory;
 import org.akvo.flow.data.preference.Prefs;
 import org.akvo.flow.data.repository.FileDataRepository;
+import org.akvo.flow.data.repository.SetupDataRepository;
 import org.akvo.flow.data.repository.SurveyDataRepository;
 import org.akvo.flow.data.repository.UserDataRepository;
 import org.akvo.flow.database.DatabaseHelper;
@@ -43,6 +44,7 @@ import org.akvo.flow.database.LanguageTable;
 import org.akvo.flow.domain.executor.PostExecutionThread;
 import org.akvo.flow.domain.executor.ThreadExecutor;
 import org.akvo.flow.domain.repository.FileRepository;
+import org.akvo.flow.domain.repository.SetupRepository;
 import org.akvo.flow.domain.repository.SurveyRepository;
 import org.akvo.flow.domain.repository.UserRepository;
 import org.akvo.flow.domain.util.ConnectivityStateManager;
@@ -115,6 +117,12 @@ public class ApplicationModule {
     @Singleton
     UserRepository provideUserRepository(UserDataRepository userDataRepository) {
         return userDataRepository;
+    }
+
+    @Provides
+    @Singleton
+    SetupRepository provideSetupRepository(SetupDataRepository setupDataRepository) {
+        return setupDataRepository;
     }
 
     @Provides

--- a/app/src/main/java/org/akvo/flow/injector/module/ViewModule.java
+++ b/app/src/main/java/org/akvo/flow/injector/module/ViewModule.java
@@ -38,6 +38,7 @@ import org.akvo.flow.domain.interactor.SaveSelectedSurvey;
 import org.akvo.flow.domain.interactor.SelectUser;
 import org.akvo.flow.domain.interactor.SaveResizedImage;
 import org.akvo.flow.domain.interactor.UseCase;
+import org.akvo.flow.domain.interactor.setup.SaveSetup;
 
 import javax.inject.Named;
 
@@ -147,5 +148,11 @@ public class ViewModule {
     @Named("saveResizedImage")
     UseCase provideSaveResizedImage(SaveResizedImage saveResizedImage) {
         return saveResizedImage;
+    }
+
+    @Provides
+    @Named("saveSetup")
+    UseCase provideSaveConfig(SaveSetup saveSetup) {
+        return saveSetup;
     }
 }

--- a/data/src/main/java/org/akvo/flow/data/datasource/DataSourceFactory.java
+++ b/data/src/main/java/org/akvo/flow/data/datasource/DataSourceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Stichting Akvo (Akvo Foundation)
+ * Copyright (C) 2017-2018 Stichting Akvo (Akvo Foundation)
  *
  * This file is part of Akvo Flow.
  *

--- a/data/src/main/java/org/akvo/flow/data/datasource/DataSourceFactory.java
+++ b/data/src/main/java/org/akvo/flow/data/datasource/DataSourceFactory.java
@@ -20,6 +20,7 @@
 
 package org.akvo.flow.data.datasource;
 
+import org.akvo.flow.data.datasource.preferences.SecureSharedPreferencesDataSource;
 import org.akvo.flow.data.datasource.preferences.SharedPreferencesDataSource;
 
 import javax.inject.Inject;
@@ -31,17 +32,24 @@ public class DataSourceFactory {
     private final SharedPreferencesDataSource sharedPreferencesDataSource;
     private final ImageDataSource imageDataSource;
     private final DatabaseDataSource dataBaseDataSource;
+    private final SecureSharedPreferencesDataSource secureSharedPreferencesDataSource;
 
     @Inject
     public DataSourceFactory(SharedPreferencesDataSource sharedPreferencesDataSource,
-            ImageDataSource imageDataSource, DatabaseDataSource dataBaseDataSource) {
+            ImageDataSource imageDataSource, DatabaseDataSource dataBaseDataSource,
+            SecureSharedPreferencesDataSource secureSharedPreferencesDataSource) {
         this.sharedPreferencesDataSource = sharedPreferencesDataSource;
         this.imageDataSource = imageDataSource;
         this.dataBaseDataSource = dataBaseDataSource;
+        this.secureSharedPreferencesDataSource = secureSharedPreferencesDataSource;
     }
 
     public SharedPreferencesDataSource getSharedPreferencesDataSource() {
         return sharedPreferencesDataSource;
+    }
+
+    public SecureSharedPreferencesDataSource getSecureSharedPreferencesDataSource() {
+        return secureSharedPreferencesDataSource;
     }
 
     public ImageDataSource getImageDataSource() {

--- a/data/src/main/java/org/akvo/flow/data/datasource/preferences/SecureSharedPreferencesDataSource.java
+++ b/data/src/main/java/org/akvo/flow/data/datasource/preferences/SecureSharedPreferencesDataSource.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2018 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.akvo.flow.data.datasource.preferences;
+
+import android.text.TextUtils;
+import android.util.Base64;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import io.reactivex.Observable;
+
+@Singleton
+public class SecureSharedPreferencesDataSource {
+
+    private static final String PREF_API_KEY = "pref_api_key";
+    private static final String PREF_AWS_ACCESS_KEY_ID = "pref_aws_access_key_id";
+    private static final String PREF_AWS_BUCKET = "pref_aws_bucket";
+    private static final String PREF_AWS_SECRET_KEY = "pref_aws_secret_key";
+    private static final String PREF_INSTANCE_URL = "pref_instance_url";
+    private static final String PREF_SERVER_BASE = "pref_server_base";
+    private static final String PREF_SIGNING_KEY = "pref_signing_key";
+
+    private final SharedPreferencesDataSource sharedPreferencesDataSource;
+
+    @Inject
+    public SecureSharedPreferencesDataSource(
+            SharedPreferencesDataSource sharedPreferencesDataSource) {
+        this.sharedPreferencesDataSource = sharedPreferencesDataSource;
+    }
+
+    public Observable<String> getApiKey() {
+        return getEncodedPreference(PREF_API_KEY);
+    }
+
+    public Observable<Boolean> saveApiKey(String apiKey) {
+        return saveEncodedString(PREF_API_KEY, apiKey);
+    }
+
+    public Observable<String> getAwsAccessKey() {
+        return getEncodedPreference(PREF_AWS_ACCESS_KEY_ID);
+    }
+
+    public Observable<Boolean> saveAwsAccessKey(String awsAccessKey) {
+        return saveEncodedString(PREF_AWS_ACCESS_KEY_ID, awsAccessKey);
+    }
+
+    public Observable<String> getAwsBucket() {
+        return getEncodedPreference(PREF_AWS_BUCKET);
+    }
+
+    public Observable<Boolean> saveAwsBucket(String awsBucket) {
+        return saveEncodedString(PREF_AWS_BUCKET, awsBucket);
+    }
+
+    public Observable<String> getAwsSecretKey() {
+        return getEncodedPreference(PREF_AWS_SECRET_KEY);
+    }
+
+    public Observable<Boolean> saveAwsSecretKey(String awsSecretKey) {
+        return saveEncodedString(PREF_AWS_SECRET_KEY, awsSecretKey);
+    }
+
+    public Observable<String> getInstanceUrl() {
+        return getEncodedPreference(PREF_INSTANCE_URL);
+    }
+
+    public Observable<Boolean> saveInstanceUrl(String instanceUrl) {
+        return saveEncodedString(PREF_INSTANCE_URL, instanceUrl);
+    }
+
+    public Observable<String> getServerBase() {
+        return getEncodedPreference(PREF_SERVER_BASE);
+    }
+
+    public Observable<Boolean> saveServerBase(String serverBase) {
+        return saveEncodedString(PREF_SERVER_BASE, serverBase);
+    }
+
+    public Observable<String> getSigningKey() {
+        return getEncodedPreference(PREF_SIGNING_KEY);
+    }
+
+    public Observable<Boolean> saveSigningKey(String serverBase) {
+        return saveEncodedString(PREF_SIGNING_KEY, serverBase);
+    }
+
+    private Observable<Boolean> saveEncodedString(String key, String value) {
+        if (!TextUtils.isEmpty(value)) {
+            sharedPreferencesDataSource.setString(encode(key), encode(value));
+        }
+        return Observable.just(true);
+    }
+
+    private Observable<String> getEncodedPreference(String key) {
+        String encodedValue = sharedPreferencesDataSource.getString(encode(key), "");
+        if (TextUtils.isEmpty(encodedValue)) {
+            return Observable.just("");
+        }
+        return Observable.just(decode(encodedValue));
+    }
+
+    private String encode(String input) {
+        return Base64.encodeToString(input.getBytes(), Base64.DEFAULT);
+    }
+
+    private String decode(String input) {
+        return new String(Base64.decode(input, Base64.DEFAULT));
+    }
+}

--- a/data/src/main/java/org/akvo/flow/data/datasource/preferences/SecureSharedPreferencesDataSource.java
+++ b/data/src/main/java/org/akvo/flow/data/datasource/preferences/SecureSharedPreferencesDataSource.java
@@ -99,8 +99,8 @@ public class SecureSharedPreferencesDataSource {
         return getEncodedPreference(PREF_SIGNING_KEY);
     }
 
-    public Observable<Boolean> saveSigningKey(String serverBase) {
-        return saveEncodedString(PREF_SIGNING_KEY, serverBase);
+    public Observable<Boolean> saveSigningKey(String signingKey) {
+        return saveEncodedString(PREF_SIGNING_KEY, signingKey);
     }
 
     private Observable<Boolean> saveEncodedString(String key, String value) {

--- a/data/src/main/java/org/akvo/flow/data/datasource/preferences/SharedPreferencesDataSource.java
+++ b/data/src/main/java/org/akvo/flow/data/datasource/preferences/SharedPreferencesDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Stichting Akvo (Akvo Foundation)
+ * Copyright (C) 2017-2018 Stichting Akvo (Akvo Foundation)
  *
  * This file is part of Akvo Flow.
  *

--- a/data/src/main/java/org/akvo/flow/data/datasource/preferences/SharedPreferencesDataSource.java
+++ b/data/src/main/java/org/akvo/flow/data/datasource/preferences/SharedPreferencesDataSource.java
@@ -84,6 +84,14 @@ public class SharedPreferencesDataSource {
         return setSelectedSurvey(INVALID_ID);
     }
 
+    protected String getString(String key, String defaultValue) {
+        return preferences.getString(key, defaultValue);
+    }
+
+    protected void setString(String key, String value) {
+        preferences.edit().putString(key, value).apply();
+    }
+
     private boolean getBoolean(String key, boolean defValue) {
         return preferences.getBoolean(key, defValue);
     }
@@ -98,14 +106,6 @@ public class SharedPreferencesDataSource {
 
     private int getInt(String key, int defValue) {
         return preferences.getInt(key, defValue);
-    }
-
-    private String getString(String key, String defaultValue) {
-        return preferences.getString(key, defaultValue);
-    }
-
-    private void setString(String key, String value) {
-        preferences.edit().putString(key, value).apply();
     }
 
     private void setBoolean(String key, boolean value) {

--- a/data/src/main/java/org/akvo/flow/data/repository/SetupDataRepository.java
+++ b/data/src/main/java/org/akvo/flow/data/repository/SetupDataRepository.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2018 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.akvo.flow.data.repository;
+
+import org.akvo.flow.data.datasource.DataSourceFactory;
+import org.akvo.flow.domain.repository.SetupRepository;
+
+import javax.inject.Inject;
+
+import io.reactivex.Observable;
+
+public class SetupDataRepository implements SetupRepository {
+
+    private final DataSourceFactory dataSourceFactory;
+
+    @Inject
+    public SetupDataRepository(DataSourceFactory dataSourceFactory) {
+        this.dataSourceFactory = dataSourceFactory;
+    }
+
+    @Override
+    public Observable<String> getApiKey() {
+        return dataSourceFactory.getSecureSharedPreferencesDataSource().getApiKey();
+    }
+
+    @Override
+    public Observable<Boolean> saveApiKey(String apiKey) {
+        return dataSourceFactory.getSecureSharedPreferencesDataSource().saveApiKey(apiKey);
+    }
+
+    @Override
+    public Observable<String> getAwsAccessKey() {
+        return dataSourceFactory.getSecureSharedPreferencesDataSource().getAwsAccessKey();
+    }
+
+    @Override
+    public Observable<Boolean> saveAwsAccessKey(String awsAccessKey) {
+        return dataSourceFactory.getSecureSharedPreferencesDataSource()
+                .saveAwsAccessKey(awsAccessKey);
+    }
+
+    @Override
+    public Observable<String> getAwsBucket() {
+        return dataSourceFactory.getSecureSharedPreferencesDataSource().getAwsBucket();
+    }
+
+    @Override
+    public Observable<Boolean> saveAwsBucket(String awsBucket) {
+        return dataSourceFactory.getSecureSharedPreferencesDataSource().saveAwsBucket(awsBucket);
+    }
+
+    @Override
+    public Observable<String> getAwsSecretKey() {
+        return dataSourceFactory.getSecureSharedPreferencesDataSource().getAwsSecretKey();
+    }
+
+    @Override
+    public Observable<Boolean> saveAwsSecretKey(String awsSecretKey) {
+        return dataSourceFactory.getSecureSharedPreferencesDataSource()
+                .saveAwsSecretKey(awsSecretKey);
+    }
+
+    @Override
+    public Observable<String> getInstanceUrl() {
+        return dataSourceFactory.getSecureSharedPreferencesDataSource().getInstanceUrl();
+    }
+
+    @Override
+    public Observable<Boolean> saveInstanceUrl(String instanceUrl) {
+        return dataSourceFactory.getSecureSharedPreferencesDataSource()
+                .saveInstanceUrl(instanceUrl);
+    }
+
+    @Override
+    public Observable<String> getServerBase() {
+        return dataSourceFactory.getSecureSharedPreferencesDataSource().getServerBase();
+    }
+
+    @Override
+    public Observable<Boolean> saveServerBase(String serverBase) {
+        return dataSourceFactory.getSecureSharedPreferencesDataSource().saveServerBase(serverBase);
+    }
+
+    @Override
+    public Observable<String> getSigningKey() {
+        return dataSourceFactory.getSecureSharedPreferencesDataSource().getSigningKey();
+    }
+
+    @Override
+    public Observable<Boolean> saveSigningKey(String signingKey) {
+        return dataSourceFactory.getSecureSharedPreferencesDataSource().saveSigningKey(signingKey);
+    }
+}

--- a/domain/src/main/java/org/akvo/flow/domain/interactor/setup/SaveSetup.java
+++ b/domain/src/main/java/org/akvo/flow/domain/interactor/setup/SaveSetup.java
@@ -38,7 +38,7 @@ import io.reactivex.functions.Function7;
 
 public class SaveSetup extends UseCase {
 
-    public final String PARAM_SETUP = "setup";
+    public static final String PARAM_SETUP = "setup";
 
     private final SetupRepository setupRepository;
 

--- a/domain/src/main/java/org/akvo/flow/domain/interactor/setup/SaveSetup.java
+++ b/domain/src/main/java/org/akvo/flow/domain/interactor/setup/SaveSetup.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2018 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.akvo.flow.domain.interactor.setup;
+
+import android.text.TextUtils;
+
+import org.akvo.flow.domain.executor.PostExecutionThread;
+import org.akvo.flow.domain.executor.ThreadExecutor;
+import org.akvo.flow.domain.interactor.UseCase;
+import org.akvo.flow.domain.repository.SetupRepository;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
+import io.reactivex.functions.Function;
+import io.reactivex.functions.Function7;
+
+public class SaveSetup extends UseCase {
+
+    public final String PARAM_SETUP = "setup";
+
+    private final SetupRepository setupRepository;
+
+    @Inject
+    protected SaveSetup(ThreadExecutor threadExecutor,
+            PostExecutionThread postExecutionThread,
+            SetupRepository setupRepository) {
+        super(threadExecutor, postExecutionThread);
+        this.setupRepository = setupRepository;
+    }
+
+    @Override
+    protected <T> Observable buildUseCaseObservable(Map<String, T> parameters) {
+        if (parameters == null || parameters.get(PARAM_SETUP) == null) {
+            return Observable.error(new IllegalArgumentException("Missing setup params"));
+        }
+        SetUpParams params = (SetUpParams) parameters.get(PARAM_SETUP);
+        return saveSetupConfig(params);
+    }
+
+    private Observable<Boolean> saveSetupConfig(SetUpParams params) {
+        return Observable
+                .zip(saveApiKey(params.getApiKey()), saveAwsAccessKey(params.getAwsAccessKeyId()),
+                        saveAwsBucket(params.getAwsBucket()),
+                        saveAwsSecretKey(params.getAwsSecretKey()),
+                        saveInstanceUrl(params.getInstanceUrl()),
+                        saveServerBase(params.getServerBase()),
+                        saveSigningKey(params.getSigningKey()),
+                        new Function7<Boolean, Boolean, Boolean, Boolean, Boolean, Boolean, Boolean,
+                                Boolean>() {
+                            @Override
+                            public Boolean apply(Boolean aBoolean, Boolean aBoolean2,
+                                    Boolean aBoolean3, Boolean aBoolean4, Boolean aBoolean5,
+                                    Boolean aBoolean6, Boolean aBoolean7) {
+                                return true;
+                            }
+                        });
+    }
+
+    private Observable<Boolean> saveApiKey(final String apiKey) {
+        return setupRepository.getApiKey()
+                .flatMap(new Function<String, ObservableSource<Boolean>>() {
+                    @Override
+                    public ObservableSource<Boolean> apply(String savedApiKey) {
+                        if (TextUtils.isEmpty(savedApiKey)) {
+                            return setupRepository.saveApiKey(apiKey);
+                        }
+                        return Observable.just(true);
+                    }
+                });
+    }
+
+    private Observable<Boolean> saveAwsAccessKey(final String awsAccessKeyId) {
+        return setupRepository.getAwsAccessKey()
+                .flatMap(new Function<String, ObservableSource<Boolean>>() {
+                    @Override
+                    public ObservableSource<Boolean> apply(String savedAwsAccessKeyId) {
+                        if (TextUtils.isEmpty(savedAwsAccessKeyId)) {
+                            return setupRepository.saveAwsAccessKey(awsAccessKeyId);
+                        }
+                        return Observable.just(true);
+                    }
+                });
+    }
+
+    private Observable<Boolean> saveAwsBucket(final String awsBucket) {
+        return setupRepository.getAwsBucket()
+                .flatMap(new Function<String, ObservableSource<Boolean>>() {
+                    @Override
+                    public ObservableSource<Boolean> apply(String savedAwsBucket) {
+                        if (TextUtils.isEmpty(savedAwsBucket)) {
+                            return setupRepository.saveAwsBucket(awsBucket);
+                        }
+                        return Observable.just(true);
+                    }
+                });
+    }
+
+    private Observable<Boolean> saveAwsSecretKey(final String awsSecretKey) {
+        return setupRepository.getAwsSecretKey()
+                .flatMap(new Function<String, ObservableSource<Boolean>>() {
+                    @Override
+                    public ObservableSource<Boolean> apply(String savedAwsSecretKey) {
+                        if (TextUtils.isEmpty(savedAwsSecretKey)) {
+                            return setupRepository.saveAwsSecretKey(awsSecretKey);
+                        }
+                        return Observable.just(true);
+                    }
+                });
+    }
+
+    private Observable<Boolean> saveInstanceUrl(final String instanceUrl) {
+        return setupRepository.getInstanceUrl()
+                .flatMap(new Function<String, ObservableSource<Boolean>>() {
+                    @Override
+                    public ObservableSource<Boolean> apply(String savedInstanceUrl) {
+                        if (TextUtils.isEmpty(savedInstanceUrl)) {
+                            return setupRepository.saveInstanceUrl(instanceUrl);
+                        }
+                        return Observable.just(true);
+                    }
+                });
+    }
+
+    private Observable<Boolean> saveServerBase(final String serverBase) {
+        return setupRepository.getServerBase()
+                .flatMap(new Function<String, ObservableSource<Boolean>>() {
+                    @Override
+                    public ObservableSource<Boolean> apply(String savedServerBase) {
+                        if (TextUtils.isEmpty(savedServerBase)) {
+                            return setupRepository.saveServerBase(serverBase);
+                        }
+                        return Observable.just(true);
+                    }
+                });
+    }
+
+    private Observable<Boolean> saveSigningKey(final String signingKey) {
+        return setupRepository.getSigningKey()
+                .flatMap(new Function<String, ObservableSource<Boolean>>() {
+                    @Override
+                    public ObservableSource<Boolean> apply(String savedSigningKey) {
+                        if (TextUtils.isEmpty(savedSigningKey)) {
+                            return setupRepository.saveSigningKey(signingKey);
+                        }
+                        return Observable.just(true);
+                    }
+                });
+    }
+
+}

--- a/domain/src/main/java/org/akvo/flow/domain/interactor/setup/SetUpParams.java
+++ b/domain/src/main/java/org/akvo/flow/domain/interactor/setup/SetUpParams.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2018 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.akvo.flow.domain.interactor.setup;
+
+public class SetUpParams {
+
+    private final String apiKey;
+    private final String awsAccessKeyId;
+    private final String awsBucket;
+    private final String awsSecretKey;
+    private final String instanceUrl;
+    private final String serverBase ;
+    private final String signingKey;
+
+    public SetUpParams(String apiKey, String awsAccessKeyId, String awsBucket,
+            String awsSecretKey, String instanceUrl, String serverBase, String signingKey) {
+        this.apiKey = apiKey;
+        this.awsAccessKeyId = awsAccessKeyId;
+        this.awsBucket = awsBucket;
+        this.awsSecretKey = awsSecretKey;
+        this.instanceUrl = instanceUrl;
+        this.serverBase = serverBase;
+        this.signingKey = signingKey;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String getAwsAccessKeyId() {
+        return awsAccessKeyId;
+    }
+
+    public String getAwsBucket() {
+        return awsBucket;
+    }
+
+    public String getAwsSecretKey() {
+        return awsSecretKey;
+    }
+
+    public String getInstanceUrl() {
+        return instanceUrl;
+    }
+
+    public String getServerBase() {
+        return serverBase;
+    }
+
+    public String getSigningKey() {
+        return signingKey;
+    }
+}

--- a/domain/src/main/java/org/akvo/flow/domain/repository/SetupRepository.java
+++ b/domain/src/main/java/org/akvo/flow/domain/repository/SetupRepository.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2018 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.akvo.flow.domain.repository;
+
+import io.reactivex.Observable;
+
+public interface SetupRepository {
+
+    Observable<String> getApiKey();
+
+    Observable<Boolean> saveApiKey(String apiKey);
+
+    Observable<String> getAwsAccessKey();
+
+    Observable<Boolean> saveAwsAccessKey(String awsAccessKey);
+
+    Observable<String> getAwsBucket();
+
+    Observable<Boolean> saveAwsBucket(String awsBucket);
+
+    Observable<String> getAwsSecretKey();
+
+    Observable<Boolean> saveAwsSecretKey(String awsSecretKey);
+
+    Observable<String> getInstanceUrl();
+
+    Observable<Boolean> saveInstanceUrl(String instanceUrl);
+
+    Observable<String> getServerBase();
+
+    Observable<Boolean> saveServerBase(String serverBase);
+
+    Observable<String> getSigningKey();
+
+    Observable<Boolean> saveSigningKey(String signingKey);
+
+}


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
The configuration settings for each dashboard are generated at build time.
see https://github.com/akvo/akvo-flow-mobile/blob/develop/app/build.gradle#L106
If we want to publish a single app for all it will be impossible to get those after we update.
#### The solution
Save each setup string as encoded preference.
We save only once, if there is already a value it will not be overridden.
keys and values are encoded so if someone tries to read the shared preferences, he will not know exactly what they are. This is not super secure but better than have them just in plain sight.
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
