### PR TITLE
Fixed mixed up download form and reload all forms (connect #1108)

### DIFF
--- a/app/src/main/java/org/akvo/flow/presentation/settings/DownloadFormDialog.java
+++ b/app/src/main/java/org/akvo/flow/presentation/settings/DownloadFormDialog.java
@@ -30,6 +30,8 @@ import android.support.v4.app.DialogFragment;
 import android.support.v4.app.FragmentActivity;
 import android.text.TextUtils;
 import android.text.method.DigitsKeyListener;
+import android.view.LayoutInflater;
+import android.view.View;
 import android.widget.EditText;
 
 import org.akvo.flow.R;
@@ -53,10 +55,10 @@ public class DownloadFormDialog extends DialogFragment {
         AlertDialog.Builder inputDialog = new AlertDialog.Builder(activity);
         inputDialog.setTitle(R.string.downloadsurveylabel);
         inputDialog.setMessage(R.string.downloadsurveyinstr);
-
-        final EditText input = new EditText(activity);
+        View main = LayoutInflater.from(activity).inflate(R.layout.download_form_dialog, null);
+        final EditText input = (EditText) main.findViewById(R.id.form_id_et);
         input.setKeyListener(new DigitsKeyListener(false, false));
-        inputDialog.setView(input);
+        inputDialog.setView(main);
         inputDialog.setPositiveButton(R.string.okbutton, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int whichButton) {
                 String surveyId = input.getText().toString().trim();

--- a/app/src/main/java/org/akvo/flow/presentation/settings/PreferenceActivity.java
+++ b/app/src/main/java/org/akvo/flow/presentation/settings/PreferenceActivity.java
@@ -307,14 +307,14 @@ public class PreferenceActivity extends BackActivity implements PreferenceView,
 
     @Override
     public void downloadForm() {
-        DialogFragment newFragment = ReloadFormsConfirmationDialog.newInstance();
-        newFragment.show(getSupportFragmentManager(), ReloadFormsConfirmationDialog.TAG);
+        DialogFragment newFragment = DownloadFormDialog.newInstance();
+        newFragment.show(getSupportFragmentManager(), DownloadFormDialog.TAG);
     }
 
     @Override
     public void reloadForms() {
-        DialogFragment newFragment = DownloadFormDialog.newInstance();
-        newFragment.show(getSupportFragmentManager(), DownloadFormDialog.TAG);
+        DialogFragment newFragment = ReloadFormsConfirmationDialog.newInstance();
+        newFragment.show(getSupportFragmentManager(), ReloadFormsConfirmationDialog.TAG);
     }
 
     @Override

--- a/app/src/main/res/layout/download_form_dialog.xml
+++ b/app/src/main/res/layout/download_form_dialog.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content">
+
+    <EditText
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginRight="16dp"
+            android:layout_marginLeft="16dp"
+            android:inputType="text"
+            android:ems="10"
+            android:singleLine="true"
+            android:hint="@string/form_id_hint"
+            android:id="@+id/form_id_et"/>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -302,5 +302,6 @@
     <string name="about_view_old_version">You can no longer update your Flow app and enjoy our latest improvements. This is because your device runs an Android version older than 4.0.3.</string>
     <string name="do_not_show_again">Do not show again</string>
     <string name="attribution">* dinosaurs by Sumana Chamrunworakiat from the Noun Project</string>
+    <string name="form_id_hint">Form id</string>
 
 </resources>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Download form and reload all forms logic was mixed up. Download form dialog had ugly margins
#### The solution
Fix the mixup and add margins to the dialog input via using a layout file
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
