### PR TITLE
Dismissing preference activity once delete has been performed (connect #1058)

### DIFF
--- a/app/src/main/java/org/akvo/flow/presentation/settings/PreferenceActivity.java
+++ b/app/src/main/java/org/akvo/flow/presentation/settings/PreferenceActivity.java
@@ -361,6 +361,11 @@ public class PreferenceActivity extends BackActivity implements PreferenceView,
         presenter.deleteAllConfirmed();
     }
 
+    @Override
+    public void dismiss() {
+        finish();
+    }
+
     private void showMessage(int resId) {
         snackBarManager.displaySnackBar(instanceNameTv, resId, this);
     }

--- a/app/src/main/java/org/akvo/flow/presentation/settings/PreferencePresenter.java
+++ b/app/src/main/java/org/akvo/flow/presentation/settings/PreferencePresenter.java
@@ -211,6 +211,7 @@ public class PreferencePresenter implements Presenter {
         public void onNext(Boolean cleared) {
             if (cleared) {
                 view.showClearDataSuccess();
+                view.dismiss();
             } else {
                 view.showClearDataError();
             }

--- a/app/src/main/java/org/akvo/flow/presentation/settings/PreferenceView.java
+++ b/app/src/main/java/org/akvo/flow/presentation/settings/PreferenceView.java
@@ -41,4 +41,6 @@ public interface PreferenceView {
     void showClearDataError();
 
     void showClearDataSuccess();
+
+    void dismiss();
 }


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
after deleting data or all we still display the remaining time for the published files even if those get deleted
#### The solution
after both delete actions dismiss the preferences, if user comes back to them, he will see the data is not published.
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
