### PR TITLE
Fixed published files get deleted when device reboots (connect #1044)

### DIFF
--- a/app/src/main/java/org/akvo/flow/broadcast/BootReceiver.java
+++ b/app/src/main/java/org/akvo/flow/broadcast/BootReceiver.java
@@ -76,7 +76,7 @@ public class BootReceiver extends BroadcastReceiver {
                     if (timeSincePublished < PublishedTimeHelper.MAX_PUBLISH_TIME_IN_MS) {
                         int timeLeft = publishedTimeHelper
                                 .getRemainingPublishedTime(timeSincePublished);
-                        alarmHelper.scheduleAlarm(timeLeft);
+                        alarmHelper.scheduleAlarm(timeLeft * 60 * 1000);
                     } else {
                         bootReceiverHelper.disableBootReceiver();
                         appContext.startService(new Intent(appContext, UnPublishDataService.class));


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When device was reboot, the published files were deleted but the timer displayed in the ui was not reset
#### The solution
The alarm received a time in minutes instead of ms.
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
