### PR TITLE
Fix transmission paths (connect #1084)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,9 @@ sentry.properties
 
 !/util/upload-apk/build/libs/deploy-1.0.jar
 
-#fastlane
+#CI config
 fastlane/report.xml
 fastlane/README.md
 build_config
 .env.default
+app/fabric.properties

--- a/app/src/main/java/org/akvo/flow/activity/TransmissionHistoryActivity.java
+++ b/app/src/main/java/org/akvo/flow/activity/TransmissionHistoryActivity.java
@@ -86,7 +86,7 @@ public class TransmissionHistoryActivity extends BackActivity {
 
     private void getTransmissionData() {
         List<FileTransmission> transmissionList = databaseAdapter
-                .getFileTransmissions(surveyInstanceId);
+                .getSurveyInstanceTransmissions(surveyInstanceId);
         displayTransmissionData(transmissionList);
     }
 

--- a/app/src/main/java/org/akvo/flow/data/database/SurveyDbDataSource.java
+++ b/app/src/main/java/org/akvo/flow/data/database/SurveyDbDataSource.java
@@ -507,16 +507,16 @@ public class SurveyDbDataSource {
     }
 
     public void setFileTransmissionFailed(String filename) {
-        int rows = updateTransmissionStatus(filename, TransmissionStatus.FAILED);
+        int rows = briteSurveyDbAdapter
+                .updateFailedTransmission(filename, TransmissionStatus.FAILED);
         if (rows == 0) {
             // Use a dummy "-1" as survey_instance_id, as the database needs that attribute
-            briteSurveyDbAdapter
-                    .createTransmission(-1, null, filename, TransmissionStatus.FAILED);
+            briteSurveyDbAdapter.createTransmission(-1, null, filename, TransmissionStatus.FAILED);
         }
     }
 
-    public int updateTransmissionStatus(String filename, int status) {
-        return surveyDbAdapter.updateTransmissionStatus(filename, status);
+    public void updateTransmissionStatus(long id, int status) {
+        briteSurveyDbAdapter.updateTransmissionStatus(id, status);
     }
 
     public void deleteResponse(long mSurveyInstanceId, String questionId, String iteration) {

--- a/app/src/main/java/org/akvo/flow/data/database/SurveyDbDataSource.java
+++ b/app/src/main/java/org/akvo/flow/data/database/SurveyDbDataSource.java
@@ -547,42 +547,22 @@ public class SurveyDbDataSource {
         surveyDbAdapter.deleteResponse(mSurveyInstanceId, questionId);
     }
 
-    private void createTransmission(long surveyInstanceId, String formId, String filename,
-            int status) {
-        ContentValues values = new ContentValues();
-        values.put(TransmissionColumns.SURVEY_INSTANCE_ID, surveyInstanceId);
-        values.put(TransmissionColumns.SURVEY_ID, formId);
-        values.put(TransmissionColumns.FILENAME, filename);
-        values.put(TransmissionColumns.STATUS, status);
-        if (TransmissionStatus.SYNCED == status) {
-            final String date = String.valueOf(System.currentTimeMillis());
-            values.put(TransmissionColumns.START_DATE, date);
-            values.put(TransmissionColumns.END_DATE, date);
-        }
-        surveyDbAdapter.createTransmission(values);
-    }
-
     public void createTransmission(long surveyInstanceId, String formId, String filename) {
-        createTransmission(surveyInstanceId, formId, filename, TransmissionStatus.QUEUED);
+        briteSurveyDbAdapter
+                .createTransmission(surveyInstanceId, formId, filename, TransmissionStatus.QUEUED);
     }
 
     public void setFileTransmissionFailed(String filename) {
-        int rows = updateTransmissionHistory(filename, TransmissionStatus.FAILED);
+        int rows = updateTransmissionStatus(filename, TransmissionStatus.FAILED);
         if (rows == 0) {
             // Use a dummy "-1" as survey_instance_id, as the database needs that attribute
-            createTransmission(-1, null, filename, TransmissionStatus.FAILED);
+            briteSurveyDbAdapter
+                    .createTransmission(-1, null, filename, TransmissionStatus.FAILED);
         }
     }
 
-    public int updateTransmissionHistory(String filename, int status) {
-        ContentValues values = new ContentValues();
-        values.put(TransmissionColumns.STATUS, status);
-        if (TransmissionStatus.SYNCED == status) {
-            values.put(TransmissionColumns.END_DATE, System.currentTimeMillis() + "");
-        } else if (TransmissionStatus.IN_PROGRESS == status) {
-            values.put(TransmissionColumns.START_DATE, System.currentTimeMillis() + "");
-        }
-        return surveyDbAdapter.updateTransmission(filename, values);
+    public int updateTransmissionStatus(String filename, int status) {
+        return surveyDbAdapter.updateTransmissionStatus(filename, status);
     }
 
     public void deleteResponse(long mSurveyInstanceId, String questionId, String iteration) {

--- a/app/src/main/java/org/akvo/flow/data/database/SurveyDbDataSource.java
+++ b/app/src/main/java/org/akvo/flow/data/database/SurveyDbDataSource.java
@@ -39,7 +39,6 @@ import org.akvo.flow.database.SurveyDbAdapter;
 import org.akvo.flow.database.SurveyGroupColumns;
 import org.akvo.flow.database.SurveyInstanceColumns;
 import org.akvo.flow.database.SurveyInstanceStatus;
-import org.akvo.flow.database.TransmissionColumns;
 import org.akvo.flow.database.TransmissionStatus;
 import org.akvo.flow.database.britedb.BriteSurveyDbAdapter;
 import org.akvo.flow.domain.FileTransmission;
@@ -51,7 +50,6 @@ import org.akvo.flow.util.ConstantUtil;
 import org.akvo.flow.util.PlatformUtil;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +64,7 @@ public class SurveyDbDataSource {
     private final SurveyDbAdapter surveyDbAdapter;
     private final BriteSurveyDbAdapter briteSurveyDbAdapter;
     private final SurveyMapper surveyMapper = new SurveyMapper();
+    private final TransmissionsMapper transmissionsMapper = new TransmissionsMapper();
 
     @Inject
     public SurveyDbDataSource(Context context, BriteDatabase briteDatabase) {
@@ -313,63 +312,18 @@ public class SurveyDbDataSource {
         return survey;
     }
 
-    @NonNull
-    private List<FileTransmission> getFileTransmissions(Cursor cursor) {
-        List<FileTransmission> transmissions = new ArrayList<>();
-
-        if (cursor != null) {
-            if (cursor.moveToFirst()) {
-                final int startCol = cursor.getColumnIndexOrThrow(TransmissionColumns.START_DATE);
-                final int endCol = cursor.getColumnIndexOrThrow(TransmissionColumns.END_DATE);
-                final int idCol = cursor.getColumnIndexOrThrow(TransmissionColumns._ID);
-                final int formIdCol = cursor.getColumnIndexOrThrow(TransmissionColumns.SURVEY_ID);
-                final int surveyInstanceCol = cursor
-                        .getColumnIndexOrThrow(TransmissionColumns.SURVEY_INSTANCE_ID);
-                final int fileCol = cursor.getColumnIndexOrThrow(TransmissionColumns.FILENAME);
-                final int statusCol = cursor.getColumnIndexOrThrow(TransmissionColumns.STATUS);
-
-                transmissions = new ArrayList<>();
-                do {
-                    FileTransmission trans = new FileTransmission();
-                    trans.setId(cursor.getLong(idCol));
-                    trans.setFormId(cursor.getString(formIdCol));
-                    trans.setRespondentId(cursor.getLong(surveyInstanceCol));
-                    trans.setFileName(cursor.getString(fileCol));
-                    trans.setStatus(cursor.getInt(statusCol));
-
-                    // Start and End date. Handle null cases
-                    if (!cursor.isNull(startCol)) {
-                        trans.setStartDate(new Date(cursor.getLong(startCol)));
-                    }
-                    if (!cursor.isNull(endCol)) {
-                        trans.setEndDate(new Date(cursor.getLong(endCol)));
-                    }
-
-                    transmissions.add(trans);
-                } while (cursor.moveToNext());
-            }
-            cursor.close();
-        }
-
-        return transmissions;
-    }
-
-    public List<FileTransmission> getFileTransmissions(long surveyInstanceId) {
-        Cursor cursor = surveyDbAdapter.getFileTransmissions(surveyInstanceId);
-        return getFileTransmissions(cursor);
+    public List<FileTransmission> getSurveyInstanceTransmissions(long surveyInstanceId) {
+        Cursor cursor = surveyDbAdapter.getSurveyInstanceTransmissions(surveyInstanceId);
+        return transmissionsMapper.getFileTransmissions(cursor);
     }
 
     /**
-     * Get the list of queued and failed transmissions
+     * Get the list of queued, in progress and failed transmissions
      */
     @NonNull
     public List<FileTransmission> getUnSyncedTransmissions() {
-        Cursor cursor = surveyDbAdapter.getUnSyncedTransmissions(new String[] {
-                String.valueOf(TransmissionStatus.FAILED),
-                String.valueOf(TransmissionStatus.IN_PROGRESS),// Stalled IN_PROGRESS files
-                String.valueOf(TransmissionStatus.QUEUED)
-        });
-        return getFileTransmissions(cursor);
+        Cursor cursor = surveyDbAdapter.getUnSyncedTransmissions();
+        return transmissionsMapper.getFileTransmissions(cursor);
     }
 
     public void addSurveyGroup(SurveyGroup surveyGroup) {

--- a/app/src/main/java/org/akvo/flow/data/database/TransmissionsMapper.java
+++ b/app/src/main/java/org/akvo/flow/data/database/TransmissionsMapper.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.akvo.flow.data.database;
+
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+
+import org.akvo.flow.database.TransmissionColumns;
+import org.akvo.flow.domain.FileTransmission;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class TransmissionsMapper {
+
+    @NonNull
+    List<FileTransmission> getFileTransmissions(Cursor cursor) {
+        List<FileTransmission> transmissions = new ArrayList<FileTransmission>();
+
+        if (cursor != null) {
+            if (cursor.moveToFirst()) {
+                final int startCol = cursor.getColumnIndexOrThrow(TransmissionColumns.START_DATE);
+                final int endCol = cursor.getColumnIndexOrThrow(TransmissionColumns.END_DATE);
+                final int idCol = cursor.getColumnIndexOrThrow(TransmissionColumns._ID);
+                final int formIdCol = cursor.getColumnIndexOrThrow(TransmissionColumns.SURVEY_ID);
+                final int surveyInstanceCol = cursor
+                        .getColumnIndexOrThrow(TransmissionColumns.SURVEY_INSTANCE_ID);
+                final int fileCol = cursor.getColumnIndexOrThrow(TransmissionColumns.FILENAME);
+                final int statusCol = cursor.getColumnIndexOrThrow(TransmissionColumns.STATUS);
+
+                transmissions = new ArrayList<>();
+                do {
+                    FileTransmission trans = new FileTransmission();
+                    trans.setId(cursor.getLong(idCol));
+                    trans.setFormId(cursor.getString(formIdCol));
+                    trans.setRespondentId(cursor.getLong(surveyInstanceCol));
+                    trans.setFileName(cursor.getString(fileCol));
+                    trans.setStatus(cursor.getInt(statusCol));
+
+                    // Start and End date. Handle null cases
+                    if (!cursor.isNull(startCol)) {
+                        trans.setStartDate(new Date(cursor.getLong(startCol)));
+                    }
+                    if (!cursor.isNull(endCol)) {
+                        trans.setEndDate(new Date(cursor.getLong(endCol)));
+                    }
+
+                    transmissions.add(trans);
+                } while (cursor.moveToNext());
+            }
+            cursor.close();
+        }
+
+        return transmissions;
+    }
+}

--- a/app/src/main/java/org/akvo/flow/data/database/TransmissionsMapper.java
+++ b/app/src/main/java/org/akvo/flow/data/database/TransmissionsMapper.java
@@ -22,6 +22,7 @@ package org.akvo.flow.data.database;
 
 import android.database.Cursor;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import org.akvo.flow.database.TransmissionColumns;
 import org.akvo.flow.domain.FileTransmission;
@@ -34,7 +35,7 @@ public class TransmissionsMapper {
 
     @NonNull
     List<FileTransmission> getFileTransmissions(Cursor cursor) {
-        List<FileTransmission> transmissions = new ArrayList<FileTransmission>();
+        List<FileTransmission> transmissions = new ArrayList<>();
 
         if (cursor != null) {
             if (cursor.moveToFirst()) {
@@ -57,12 +58,8 @@ public class TransmissionsMapper {
                     trans.setStatus(cursor.getInt(statusCol));
 
                     // Start and End date. Handle null cases
-                    if (!cursor.isNull(startCol)) {
-                        trans.setStartDate(new Date(cursor.getLong(startCol)));
-                    }
-                    if (!cursor.isNull(endCol)) {
-                        trans.setEndDate(new Date(cursor.getLong(endCol)));
-                    }
+                    trans.setStartDate(getDate(cursor, startCol));
+                    trans.setEndDate(getDate(cursor, endCol));
 
                     transmissions.add(trans);
                 } while (cursor.moveToNext());
@@ -71,5 +68,13 @@ public class TransmissionsMapper {
         }
 
         return transmissions;
+    }
+
+    @Nullable
+    private Date getDate(Cursor cursor, int column) {
+        if (!cursor.isNull(column)) {
+            return new Date(cursor.getLong(column));
+        }
+        return null;
     }
 }

--- a/app/src/main/java/org/akvo/flow/service/DataSyncService.java
+++ b/app/src/main/java/org/akvo/flow/service/DataSyncService.java
@@ -552,7 +552,7 @@ public class DataSyncService extends IntentService {
             FlowApi api = new FlowApi(getApplicationContext());
             switch (api.sendProcessingNotification(formId, action, filePath)) {
                 case HttpURLConnection.HTTP_OK:
-                    status = TransmissionStatus.SYNCED;// Mark everything synced
+                    status = TransmissionStatus.SYNCED; // Mark everything synced
                     synced = true;
                     break;
                 case HttpURLConnection.HTTP_NOT_FOUND:

--- a/app/src/main/java/org/akvo/flow/service/DataSyncService.java
+++ b/app/src/main/java/org/akvo/flow/service/DataSyncService.java
@@ -552,7 +552,7 @@ public class DataSyncService extends IntentService {
             FlowApi api = new FlowApi(getApplicationContext());
             switch (api.sendProcessingNotification(formId, action, filePath)) {
                 case HttpURLConnection.HTTP_OK:
-                    status = TransmissionStatus.SYNCED;// Mark everything completed
+                    status = TransmissionStatus.SYNCED;// Mark everything synced
                     synced = true;
                     break;
                 case HttpURLConnection.HTTP_NOT_FOUND:

--- a/app/src/main/java/org/akvo/flow/service/DataSyncService.java
+++ b/app/src/main/java/org/akvo/flow/service/DataSyncService.java
@@ -479,8 +479,7 @@ public class DataSyncService extends IntentService {
         for (int i = 0; i < totalFiles; i++) {
             FileTransmission transmission = transmissions.get(i);
             final long surveyInstanceId = transmission.getRespondentId();
-            if (syncFile(transmission.getFileName(), transmission.getFormId()
-            )) {
+            if (syncFile(transmission.getFileName(), transmission.getFormId())) {
                 syncedSurveys.add(surveyInstanceId);
             } else {
                 unsyncedSurveys.add(surveyInstanceId);
@@ -528,7 +527,7 @@ public class DataSyncService extends IntentService {
 
         // Temporarily set the status to 'IN PROGRESS'. Transmission status should
         // *always* be updated with the outcome of the upload operation.
-        mDatabase.updateTransmissionHistory(filename, TransmissionStatus.IN_PROGRESS);
+        mDatabase.updateTransmissionStatus(filename, TransmissionStatus.IN_PROGRESS);
 
         int status = TransmissionStatus.FAILED;
         boolean synced = false;
@@ -551,7 +550,7 @@ public class DataSyncService extends IntentService {
             }
         }
 
-        mDatabase.updateTransmissionHistory(filename, status);
+        mDatabase.updateTransmissionStatus(filename, status);
         return synced;
     }
 

--- a/app/src/main/java/org/akvo/flow/service/DataSyncService.java
+++ b/app/src/main/java/org/akvo/flow/service/DataSyncService.java
@@ -262,9 +262,10 @@ public class DataSyncService extends IntentService {
         try {
             ZipFileData zipFileData = new ZipFileData();
             // Process form instance data and collect image filenames
+            Set<String> imagePaths = new HashSet<>();
             FormInstance formInstance = processFormInstance(surveyInstanceId,
-                    zipFileData.imagePaths);
-
+                    imagePaths);
+            zipFileData.imagePaths.addAll(imagePaths);
             // Serialize form instance as JSON
             zipFileData.data = new GsonMapper().write(formInstance, FormInstance.class);
             zipFileData.uuid = formInstance.getUUID();
@@ -287,7 +288,7 @@ public class DataSyncService extends IntentService {
             File zipFile = zipFileBrowser.getSurveyInstanceFile(zipFileData.uuid);
 
             // Write the data into the zip file
-            String fileName = zipFile.getAbsolutePath();// Will normalize filename.
+            String fileName = zipFile.getName();
             zipFileData.filename = fileName;
             Timber.i("Creating zip file: " + fileName);
             FileOutputStream fout = new FileOutputStream(zipFile);
@@ -339,7 +340,7 @@ public class DataSyncService extends IntentService {
      */
     @NonNull
     private FormInstance processFormInstance(long surveyInstanceId,
-            @NonNull List<String> imagePaths) {
+            @NonNull Set<String> imagePaths) {
         FormInstance formInstance = new FormInstance();
         List<Response> responses = new ArrayList<>();
         Cursor data = mDatabase.getResponsesData(surveyInstanceId);
@@ -391,19 +392,14 @@ public class DataSyncService extends IntentService {
                 }
 
                 // If the response has any file attached, enqueue it to the image list
-                String filename = data.getString(filename_col);
+                String filePath = data.getString(filename_col);
+                String filename = getFilenameFromPath(filePath);
+
                 if (!TextUtils.isEmpty(filename)) {
                     imagePaths.add(filename);
                 }
 
-                // Ensure backwards compatibility. Old image responses may contain filenames
                 String type = data.getString(answer_type_col);
-                if (ConstantUtil.IMAGE_RESPONSE_TYPE.equals(type)
-                        || ConstantUtil.VIDEO_RESPONSE_TYPE.equals(type)) {
-                    if (!TextUtils.isEmpty(value) && new File(value).exists()) {
-                        imagePaths.add(value);
-                    }
-                }
 
                 String rawQuestionId = data.getString(question_fk_col);
                 int iteration = data.getInt(iterationColumn);
@@ -423,10 +419,23 @@ public class DataSyncService extends IntentService {
             } while (data.moveToNext());
 
             formInstance.setResponses(responses);
+        }
+        if (data != null) {
             data.close();
         }
 
         return formInstance;
+    }
+
+    @Nullable
+    private String getFilenameFromPath(@Nullable String filePath) {
+        String filename = null;
+        if (!TextUtils.isEmpty(filePath) && filePath.contains(File.separator)
+                && filePath.contains(".")) {
+            filename = filePath.substring(filePath.lastIndexOf(File.separator) + 1);
+
+        }
+        return filename;
     }
 
     // replace troublesome chars in user-provided values
@@ -479,7 +488,7 @@ public class DataSyncService extends IntentService {
         for (int i = 0; i < totalFiles; i++) {
             FileTransmission transmission = transmissions.get(i);
             final long surveyInstanceId = transmission.getRespondentId();
-            if (syncFile(transmission.getFileName(), transmission.getFormId())) {
+            if (syncFile(transmission)) {
                 syncedSurveys.add(surveyInstanceId);
             } else {
                 unsyncedSurveys.add(surveyInstanceId);
@@ -499,13 +508,18 @@ public class DataSyncService extends IntentService {
         }
     }
 
-    private boolean syncFile(@NonNull String filename, @NonNull String formId) {
+    private boolean syncFile(@NonNull FileTransmission transmission) {
+        String filename = transmission.getFileName();
+        String formId = transmission.getFormId();
         if (TextUtils.isEmpty(filename) || filename.lastIndexOf(".") < 0) {
             return false;
         }
 
-        String contentType, dir, action;
+        String contentType;
+        String dir;
+        String action;
         boolean isPublic;
+        String filePath;
         String ext = filename.substring(filename.lastIndexOf("."));
         contentType = contentType(ext);
         switch (ext) {
@@ -515,11 +529,13 @@ public class DataSyncService extends IntentService {
                 dir = ConstantUtil.S3_IMAGE_DIR;
                 action = ACTION_IMAGE;
                 isPublic = true;// Images/Videos have a public read policy
+                filePath = buildMediaFilePath(filename);
                 break;
             case ConstantUtil.ARCHIVE_SUFFIX:
                 dir = ConstantUtil.S3_DATA_DIR;
                 action = ACTION_SUBMIT;
                 isPublic = false;
+                filePath = buildZipFilePath(filename);
                 break;
             default:
                 return false;
@@ -527,15 +543,14 @@ public class DataSyncService extends IntentService {
 
         // Temporarily set the status to 'IN PROGRESS'. Transmission status should
         // *always* be updated with the outcome of the upload operation.
-        mDatabase.updateTransmissionStatus(filename, TransmissionStatus.IN_PROGRESS);
+        mDatabase.updateTransmissionStatus(transmission.getId(), TransmissionStatus.IN_PROGRESS);
 
         int status = TransmissionStatus.FAILED;
         boolean synced = false;
 
-        if (sendFile(filename, dir, contentType, isPublic, FILE_UPLOAD_RETRIES)) {
+        if (sendFile(filePath, dir, contentType, isPublic, FILE_UPLOAD_RETRIES)) {
             FlowApi api = new FlowApi(getApplicationContext());
-            switch (api.sendProcessingNotification(formId, action,
-                    getDestName(filename))) {
+            switch (api.sendProcessingNotification(formId, action, filePath)) {
                 case HttpURLConnection.HTTP_OK:
                     status = TransmissionStatus.SYNCED;// Mark everything completed
                     synced = true;
@@ -550,8 +565,16 @@ public class DataSyncService extends IntentService {
             }
         }
 
-        mDatabase.updateTransmissionStatus(filename, status);
+        mDatabase.updateTransmissionStatus(transmission.getId(), status);
         return synced;
+    }
+
+    private String buildZipFilePath(String filename) {
+        return zipFileBrowser.getZipFile(filename).getAbsolutePath();
+    }
+
+    private String buildMediaFilePath(String filename) {
+        return mediaFileHelper.getMediaFile(filename).getAbsolutePath();
     }
 
     private boolean sendFile(@NonNull String fileAbsolutePath, String dir, String contentType,
@@ -604,9 +627,10 @@ public class DataSyncService extends IntentService {
                 // Handle missing files. If an unknown file exists in the filesystem
                 // it will be marked as failed in the transmission history, so it can
                 // be handled and retried in the next sync attempt.
-                for (String filename : files) {
-                    if (new File(filename).exists()) {
-                        mDatabase.setFileTransmissionFailed(filename);
+                for (String filePath : files) {
+                    String filenameFromPath = getFilenameFromPath(filePath);
+                    if (!TextUtils.isEmpty(filenameFromPath)) {
+                        mDatabase.setFileTransmissionFailed(filenameFromPath);
                     }
                 }
 
@@ -649,17 +673,6 @@ public class DataSyncService extends IntentService {
             }
         }
         return files;
-    }
-
-    @NonNull
-    private static String getDestName(@NonNull String filename) {
-        if (filename.contains("/")) {
-            return filename.substring(filename.lastIndexOf("/") + 1);
-        } else if (filename.contains("\\")) {
-            filename = filename.substring(filename.lastIndexOf("\\") + 1);
-        }
-
-        return filename;
     }
 
     private void updateSurveyStatus(long surveyInstanceId, int status) {

--- a/app/src/main/java/org/akvo/flow/util/files/ZipFileBrowser.java
+++ b/app/src/main/java/org/akvo/flow/util/files/ZipFileBrowser.java
@@ -21,12 +21,10 @@
 package org.akvo.flow.util.files;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
 
 import org.akvo.flow.util.ConstantUtil;
 
 import java.io.File;
-import java.util.List;
 
 import javax.inject.Inject;
 
@@ -48,8 +46,7 @@ public class ZipFileBrowser {
                 uuid + ConstantUtil.ARCHIVE_SUFFIX);
     }
 
-    @NonNull
-    public List<File> findAllPossibleFolders() {
-        return fileBrowser.findAllPossibleFolders(context, DIR_DATA);
+    public File getZipFile(String filename) {
+        return new File(fileBrowser.getExistingAppInternalFolder(context, DIR_DATA), filename);
     }
 }

--- a/data/src/main/java/org/akvo/flow/data/datasource/DatabaseDataSource.java
+++ b/data/src/main/java/org/akvo/flow/data/datasource/DatabaseDataSource.java
@@ -30,14 +30,12 @@ import com.squareup.sqlbrite2.BriteDatabase;
 import org.akvo.flow.data.entity.ApiDataPoint;
 import org.akvo.flow.data.entity.ApiQuestionAnswer;
 import org.akvo.flow.data.entity.ApiSurveyInstance;
-import org.akvo.flow.data.entity.MovedFile;
 import org.akvo.flow.database.Constants;
 import org.akvo.flow.database.RecordColumns;
 import org.akvo.flow.database.ResponseColumns;
 import org.akvo.flow.database.SurveyInstanceColumns;
 import org.akvo.flow.database.SurveyInstanceStatus;
 import org.akvo.flow.database.SyncTimeColumns;
-import org.akvo.flow.database.TransmissionStatus;
 import org.akvo.flow.database.britedb.BriteSurveyDbAdapter;
 import org.akvo.flow.domain.entity.User;
 
@@ -104,19 +102,6 @@ public class DatabaseDataSource {
         }
     }
 
-
-    public void updateTransmissions(@NonNull List<MovedFile> movedFiles) {
-        BriteDatabase.Transaction transaction = briteSurveyDbAdapter.beginTransaction();
-        try {
-            for (MovedFile file: movedFiles) {
-                briteSurveyDbAdapter.updateTransmission(file.getOldPath(), file.getNewPath());
-            }
-            transaction.markSuccessful();
-        } finally {
-            transaction.end();
-        }
-    }
-
     private boolean isRequestFiltered(@Nullable Integer orderBy) {
         return orderBy != null && (orderBy == Constants.ORDER_BY_DISTANCE ||
                 orderBy == Constants.ORDER_BY_DATE ||
@@ -166,12 +151,6 @@ public class DatabaseDataSource {
             long id = briteSurveyDbAdapter.syncSurveyInstance(values, surveyInstance.getUuid());
 
             syncResponses(surveyInstance.getQasList(), id);
-
-            // The filename is a unique column in the transmission table, and as we do not have
-            // a file to hold this data, we set the value to the instance UUID
-            briteSurveyDbAdapter
-                    .createTransmission(id, String.valueOf(surveyInstance.getSurveyId()),
-                            surveyInstance.getUuid(), TransmissionStatus.SYNCED);
         }
         briteSurveyDbAdapter.deleteEmptyRecords();
     }

--- a/data/src/main/java/org/akvo/flow/data/datasource/DatabaseDataSource.java
+++ b/data/src/main/java/org/akvo/flow/data/datasource/DatabaseDataSource.java
@@ -237,12 +237,11 @@ public class DatabaseDataSource {
         return Observable.just(true);
     }
 
-    public boolean unSyncedTransmissionsExist() {
-        return briteSurveyDbAdapter.unSyncedTransmissionsExist();
+    public Observable<Boolean> unSyncedTransmissionsExist() {
+        return Observable.just(briteSurveyDbAdapter.unSyncedTransmissionsExist());
     }
 
-    public Observable<Cursor> getAllTransmissionFileNames() {
-        return Observable
-                .just(briteSurveyDbAdapter.getAllTransmissionFileNames());
+    public Observable<Cursor> getAllTransmissions() {
+        return Observable.just(briteSurveyDbAdapter.getAllTransmissions());
     }
 }

--- a/data/src/main/java/org/akvo/flow/data/datasource/DatabaseDataSource.java
+++ b/data/src/main/java/org/akvo/flow/data/datasource/DatabaseDataSource.java
@@ -171,8 +171,7 @@ public class DatabaseDataSource {
             // a file to hold this data, we set the value to the instance UUID
             briteSurveyDbAdapter
                     .createTransmission(id, String.valueOf(surveyInstance.getSurveyId()),
-                            surveyInstance.getUuid(),
-                            TransmissionStatus.SYNCED);
+                            surveyInstance.getUuid(), TransmissionStatus.SYNCED);
         }
         briteSurveyDbAdapter.deleteEmptyRecords();
     }

--- a/data/src/main/java/org/akvo/flow/data/datasource/FileDataSource.java
+++ b/data/src/main/java/org/akvo/flow/data/datasource/FileDataSource.java
@@ -145,10 +145,10 @@ public class FileDataSource {
         if (dataFolder.exists()) {
             File[] files = dataFolder.listFiles();
             if (files != null) {
-                for (File f : files) {
-                    if (fileNames.contains(f.getAbsolutePath())) {
+                for (File fileToMove : files) {
+                    if (fileNames.contains(fileToMove.getName())) {
                         filesCopied = true;
-                        fileHelper.copyFileToFolder(f, destinationDataFolder);
+                        fileHelper.copyFileToFolder(fileToMove, destinationDataFolder);
                     }
                 }
             }

--- a/data/src/main/java/org/akvo/flow/data/entity/TransmissionFilenameMapper.java
+++ b/data/src/main/java/org/akvo/flow/data/entity/TransmissionFilenameMapper.java
@@ -31,10 +31,10 @@ import javax.inject.Inject;
 
 import io.reactivex.annotations.Nullable;
 
-public class TransmissionMapper {
+public class TransmissionFilenameMapper {
 
     @Inject
-    public TransmissionMapper() {
+    public TransmissionFilenameMapper() {
     }
 
     public List<String> mapToFileNameList(@Nullable Cursor cursor) {
@@ -52,7 +52,7 @@ public class TransmissionMapper {
     }
 
     private String getFileName(Cursor cursor) {
-        return cursor.getString(
-                cursor.getColumnIndexOrThrow(TransmissionColumns.FILENAME));
+        return cursor
+                .getString(cursor.getColumnIndexOrThrow(TransmissionColumns.FILENAME));
     }
 }

--- a/data/src/main/java/org/akvo/flow/data/repository/FileDataRepository.java
+++ b/data/src/main/java/org/akvo/flow/data/repository/FileDataRepository.java
@@ -63,8 +63,7 @@ public class FileDataRepository implements FileRepository {
                 dataSourceFactory.getFileDataSource().moveMediaFiles())
                 .concatMap(new Function<List<MovedFile>, Observable<Boolean>>() {
                     @Override
-                    public Observable<Boolean> apply(List<MovedFile> movedFiles) throws Exception {
-                        dataSourceFactory.getDataBaseDataSource().updateTransmissions(movedFiles);
+                    public Observable<Boolean> apply(List<MovedFile> movedFiles) {
                         return Observable.just(true);
                     }
                 });

--- a/data/src/main/java/org/akvo/flow/data/repository/SurveyDataRepository.java
+++ b/data/src/main/java/org/akvo/flow/data/repository/SurveyDataRepository.java
@@ -29,7 +29,7 @@ import org.akvo.flow.data.entity.ApiSurveyInstance;
 import org.akvo.flow.data.entity.DataPointMapper;
 import org.akvo.flow.data.entity.SurveyMapper;
 import org.akvo.flow.data.entity.SyncedTimeMapper;
-import org.akvo.flow.data.entity.TransmissionMapper;
+import org.akvo.flow.data.entity.TransmissionFilenameMapper;
 import org.akvo.flow.data.entity.UserMapper;
 import org.akvo.flow.data.net.FlowRestApi;
 import org.akvo.flow.domain.entity.DataPoint;
@@ -66,13 +66,13 @@ public class SurveyDataRepository implements SurveyRepository {
     private final FlowRestApi restApi;
     private final SurveyMapper surveyMapper;
     private final UserMapper userMapper;
-    private final TransmissionMapper transmissionMapper;
+    private final TransmissionFilenameMapper transmissionMapper;
 
     @Inject
     public SurveyDataRepository(DataSourceFactory dataSourceFactory,
             DataPointMapper dataPointMapper, SyncedTimeMapper syncedTimeMapper, FlowRestApi restApi,
             SurveyMapper surveyMapper, UserMapper userMapper,
-            TransmissionMapper transmissionMapper) {
+            TransmissionFilenameMapper transmissionMapper) {
         this.dataSourceFactory = dataSourceFactory;
         this.dataPointMapper = dataPointMapper;
         this.syncedTimeMapper = syncedTimeMapper;
@@ -308,13 +308,12 @@ public class SurveyDataRepository implements SurveyRepository {
 
     @Override
     public Observable<Boolean> unSyncedTransmissionsExist() {
-        return Observable
-                .just(dataSourceFactory.getDataBaseDataSource().unSyncedTransmissionsExist());
+        return dataSourceFactory.getDataBaseDataSource().unSyncedTransmissionsExist();
     }
 
     @Override
     public Observable<List<String>> getAllTransmissionFileNames() {
-        return dataSourceFactory.getDataBaseDataSource().getAllTransmissionFileNames()
+        return dataSourceFactory.getDataBaseDataSource().getAllTransmissions()
                 .map(new Function<Cursor, List<String>>() {
                     @Override
                     public List<String> apply(Cursor cursor) {

--- a/data/src/main/java/org/akvo/flow/data/repository/SurveyDataRepository.java
+++ b/data/src/main/java/org/akvo/flow/data/repository/SurveyDataRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Stichting Akvo (Akvo Foundation)
+ * Copyright (C) 2017-2018 Stichting Akvo (Akvo Foundation)
  *
  * This file is part of Akvo Flow.
  *

--- a/database/src/main/java/org/akvo/flow/database/DatabaseHelper.java
+++ b/database/src/main/java/org/akvo/flow/database/DatabaseHelper.java
@@ -270,5 +270,4 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         db.execSQL("DROP TABLE IF EXISTS " + Tables.TRANSMISSION);
     }
 
-
 }

--- a/database/src/main/java/org/akvo/flow/database/SurveyDbAdapter.java
+++ b/database/src/main/java/org/akvo/flow/database/SurveyDbAdapter.java
@@ -306,26 +306,6 @@ public class SurveyDbAdapter {
                 });
     }
 
-    /**
-     * Updates the matching transmission history records with the status
-     * passed in. If the status == Completed, the completion date is updated. If
-     * the status == In Progress, the start date is updated.
-     *
-     * @return the number of rows affected
-     */
-    public int updateTransmissionStatus(String fileName, int status) {
-        // TODO: Update Survey Instance STATUS as well
-        ContentValues values = new ContentValues();
-        values.put(TransmissionColumns.STATUS, status);
-        if (TransmissionStatus.SYNCED == status) {
-            values.put(TransmissionColumns.END_DATE, System.currentTimeMillis() + "");
-        } else if (TransmissionStatus.IN_PROGRESS == status) {
-            values.put(TransmissionColumns.START_DATE, System.currentTimeMillis() + "");
-        }
-        return database.update(Tables.TRANSMISSION, values, TransmissionColumns.FILENAME + " = ?",
-                new String[] { fileName });
-    }
-
     public Cursor getSurveyInstanceTransmissions(long surveyInstanceId) {
         return getTransmissions(TransmissionColumns.SURVEY_INSTANCE_ID + " = ?",
                 new String[] { String.valueOf(surveyInstanceId) }

--- a/database/src/main/java/org/akvo/flow/database/SurveyDbAdapter.java
+++ b/database/src/main/java/org/akvo/flow/database/SurveyDbAdapter.java
@@ -308,14 +308,16 @@ public class SurveyDbAdapter {
 
     public Cursor getSurveyInstanceTransmissions(long surveyInstanceId) {
         return getTransmissions(TransmissionColumns.SURVEY_INSTANCE_ID + " = ?",
-                new String[] { String.valueOf(surveyInstanceId) }
+                new String[] {
+                        String.valueOf(surveyInstanceId)
+                }
         );
     }
 
     public Cursor getUnSyncedTransmissions() {
         return getTransmissions(TransmissionColumns.STATUS + " IN (?, ?, ?)", new String[] {
                 String.valueOf(TransmissionStatus.FAILED),
-                String.valueOf(TransmissionStatus.IN_PROGRESS),// Stalled IN_PROGRESS files
+                String.valueOf(TransmissionStatus.IN_PROGRESS), // Stalled IN_PROGRESS files
                 String.valueOf(TransmissionStatus.QUEUED)
         });
     }

--- a/database/src/main/java/org/akvo/flow/database/SurveyDbAdapter.java
+++ b/database/src/main/java/org/akvo/flow/database/SurveyDbAdapter.java
@@ -326,20 +326,21 @@ public class SurveyDbAdapter {
                 new String[] { fileName });
     }
 
-    public Cursor getFileTransmissions(long surveyInstanceId) {
-        return database.query(Tables.TRANSMISSION,
-                new String[] {
-                        TransmissionColumns._ID, TransmissionColumns.SURVEY_INSTANCE_ID,
-                        TransmissionColumns.SURVEY_ID, TransmissionColumns.STATUS,
-                        TransmissionColumns.FILENAME, TransmissionColumns.START_DATE,
-                        TransmissionColumns.END_DATE
-                },
-                TransmissionColumns.SURVEY_INSTANCE_ID + " = ?",
-                new String[] { String.valueOf(surveyInstanceId) },
-                null, null, null);
+    public Cursor getSurveyInstanceTransmissions(long surveyInstanceId) {
+        return getTransmissions(TransmissionColumns.SURVEY_INSTANCE_ID + " = ?",
+                new String[] { String.valueOf(surveyInstanceId) }
+        );
     }
 
-    public Cursor getUnSyncedTransmissions(String[] selectionArgs) {
+    public Cursor getUnSyncedTransmissions() {
+        return getTransmissions(TransmissionColumns.STATUS + " IN (?, ?, ?)", new String[] {
+                String.valueOf(TransmissionStatus.FAILED),
+                String.valueOf(TransmissionStatus.IN_PROGRESS),// Stalled IN_PROGRESS files
+                String.valueOf(TransmissionStatus.QUEUED)
+        });
+    }
+
+    private Cursor getTransmissions(String selection, String[] selectionArgs) {
         return database.query(Tables.TRANSMISSION,
                 new String[] {
                         TransmissionColumns._ID, TransmissionColumns.SURVEY_INSTANCE_ID,
@@ -347,8 +348,7 @@ public class SurveyDbAdapter {
                         TransmissionColumns.FILENAME, TransmissionColumns.START_DATE,
                         TransmissionColumns.END_DATE
                 },
-                TransmissionColumns.STATUS + " IN (?, ?, ?)",
-                selectionArgs, null, null, null);
+                selection, selectionArgs, null, null, null);
     }
 
     /**

--- a/database/src/main/java/org/akvo/flow/database/SurveyDbAdapter.java
+++ b/database/src/main/java/org/akvo/flow/database/SurveyDbAdapter.java
@@ -306,10 +306,6 @@ public class SurveyDbAdapter {
                 });
     }
 
-    public void createTransmission(ContentValues values) {
-        database.insert(Tables.TRANSMISSION, null, values);
-    }
-
     /**
      * Updates the matching transmission history records with the status
      * passed in. If the status == Completed, the completion date is updated. If
@@ -317,10 +313,16 @@ public class SurveyDbAdapter {
      *
      * @return the number of rows affected
      */
-    public int updateTransmission(String fileName, ContentValues values) {
+    public int updateTransmissionStatus(String fileName, int status) {
         // TODO: Update Survey Instance STATUS as well
-        return database.update(Tables.TRANSMISSION, values,
-                TransmissionColumns.FILENAME + " = ?",
+        ContentValues values = new ContentValues();
+        values.put(TransmissionColumns.STATUS, status);
+        if (TransmissionStatus.SYNCED == status) {
+            values.put(TransmissionColumns.END_DATE, System.currentTimeMillis() + "");
+        } else if (TransmissionStatus.IN_PROGRESS == status) {
+            values.put(TransmissionColumns.START_DATE, System.currentTimeMillis() + "");
+        }
+        return database.update(Tables.TRANSMISSION, values, TransmissionColumns.FILENAME + " = ?",
                 new String[] { fileName });
     }
 

--- a/database/src/main/java/org/akvo/flow/database/britedb/BriteSurveyDbAdapter.java
+++ b/database/src/main/java/org/akvo/flow/database/britedb/BriteSurveyDbAdapter.java
@@ -269,6 +269,7 @@ public class BriteSurveyDbAdapter {
 
     public void createTransmission(long surveyInstanceId, String formID, String filename,
             int status) {
+        Timber.d("creating transmission with file: %s", filename);
         ContentValues values = new ContentValues();
         values.put(TransmissionColumns.SURVEY_INSTANCE_ID, surveyInstanceId);
         values.put(TransmissionColumns.SURVEY_ID, formID);
@@ -533,16 +534,14 @@ public class BriteSurveyDbAdapter {
 
     public boolean unSyncedTransmissionsExist() {
         boolean transmissionsExist = false;
-        String sql =
-                "SELECT " + TransmissionColumns._ID + " FROM " + Tables.TRANSMISSION + " WHERE "
-                        + TransmissionColumns.STATUS
-                        + " IN (?, ?, ?) LIMIT 1";
+        String column = TransmissionColumns._ID;
+        String whereClause = TransmissionColumns.STATUS + " IN (?, ?, ?) LIMIT 1";
         String[] selectionArgs = new String[] {
                 String.valueOf(TransmissionStatus.FAILED),
                 String.valueOf(TransmissionStatus.IN_PROGRESS),
                 String.valueOf(TransmissionStatus.QUEUED)
         };
-        Cursor cursor = briteDatabase.query(sql, selectionArgs);
+        Cursor cursor = queryTransmissions(column, whereClause, selectionArgs);
         if (cursor != null && cursor.getCount() > 0) {
             transmissionsExist = true;
         }
@@ -552,16 +551,20 @@ public class BriteSurveyDbAdapter {
         return transmissionsExist;
     }
 
-    public Cursor getAllTransmissionFileNames() {
-        String sql =
-                "SELECT " + TransmissionColumns.FILENAME + " FROM " + Tables.TRANSMISSION
-                        + " WHERE " + TransmissionColumns.STATUS + " IN (?, ?, ?, ?)";
+    public Cursor getAllTransmissions() {
+        String column = TransmissionColumns.FILENAME;
+        String whereClause = TransmissionColumns.STATUS + " IN (?, ?, ?, ?)";
         String[] selectionArgs = new String[] {
                 String.valueOf(TransmissionStatus.QUEUED),
                 String.valueOf(TransmissionStatus.IN_PROGRESS),
                 String.valueOf(TransmissionStatus.SYNCED),
                 String.valueOf(TransmissionStatus.FAILED),
         };
+        return queryTransmissions(column, whereClause, selectionArgs);
+    }
+
+    private Cursor queryTransmissions(String column, String whereClause, String[] selectionArgs) {
+        String sql = "SELECT " + column + " FROM " + Tables.TRANSMISSION + " WHERE " + whereClause;
         return briteDatabase.query(sql, selectionArgs);
     }
 }

--- a/database/src/main/java/org/akvo/flow/database/migration/TransmissionMigrationHelper.java
+++ b/database/src/main/java/org/akvo/flow/database/migration/TransmissionMigrationHelper.java
@@ -40,12 +40,12 @@ public class TransmissionMigrationHelper {
                 TransmissionColumns._ID, TransmissionColumns.FILENAME
         }, null, null, null, null, null);
         if (cursor != null) {
-                Map<Long, ContentValues> insertions = new HashMap<>(cursor.getCount());
+            Map<Long, ContentValues> insertions = new HashMap<>(cursor.getCount());
             if (cursor.moveToFirst()) {
                 int idColumnIndex = cursor.getColumnIndexOrThrow(TransmissionColumns._ID);
                 int fileColumnIndex = cursor.getColumnIndexOrThrow(TransmissionColumns.FILENAME);
                 do {
-                   long id = cursor.getInt(idColumnIndex);
+                    long id = cursor.getInt(idColumnIndex);
                     String filePath = cursor.getString(fileColumnIndex);
                     ContentValues contentValues = new ContentValues(1);
                     if (!TextUtils.isEmpty(filePath) && filePath.contains(File.separator)
@@ -58,8 +58,8 @@ public class TransmissionMigrationHelper {
                 } while (cursor.moveToNext());
             }
             cursor.close();
-            Set<Long> longs = insertions.keySet();
-            for (long id : longs) {
+            Set<Long> transmissionIds = insertions.keySet();
+            for (long id : transmissionIds) {
                 db.update(Tables.TRANSMISSION, insertions.get(id), TransmissionColumns._ID + " =? ",
                         new String[] {
                                 id + ""

--- a/database/src/main/java/org/akvo/flow/database/migration/TransmissionMigrationHelper.java
+++ b/database/src/main/java/org/akvo/flow/database/migration/TransmissionMigrationHelper.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2018 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.akvo.flow.database.migration;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.text.TextUtils;
+
+import org.akvo.flow.database.Tables;
+import org.akvo.flow.database.TransmissionColumns;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class TransmissionMigrationHelper {
+
+    public void migrateTransmissions(SQLiteDatabase db) {
+        Cursor cursor = db.query(Tables.TRANSMISSION, new String[] {
+                TransmissionColumns._ID, TransmissionColumns.FILENAME
+        }, null, null, null, null, null);
+        if (cursor != null) {
+                Map<Long, ContentValues> insertions = new HashMap<>(cursor.getCount());
+            if (cursor.moveToFirst()) {
+                int idColumnIndex = cursor.getColumnIndexOrThrow(TransmissionColumns._ID);
+                int fileColumnIndex = cursor.getColumnIndexOrThrow(TransmissionColumns.FILENAME);
+                do {
+                   long id = cursor.getInt(idColumnIndex);
+                    String filePath = cursor.getString(fileColumnIndex);
+                    ContentValues contentValues = new ContentValues(1);
+                    if (!TextUtils.isEmpty(filePath) && filePath.contains(File.separator)
+                            && filePath.contains(".")) {
+                        int separatorIdx = filePath.lastIndexOf(File.separator);
+                        String filename = filePath.substring(separatorIdx + 1);
+                        contentValues.put(TransmissionColumns.FILENAME, filename);
+                        insertions.put(id, contentValues);
+                    }
+                } while (cursor.moveToNext());
+            }
+            cursor.close();
+            Set<Long> longs = insertions.keySet();
+            for (long id : longs) {
+                db.update(Tables.TRANSMISSION, insertions.get(id), TransmissionColumns._ID + " =? ",
+                        new String[] {
+                                id + ""
+                        });
+            }
+        }
+
+    }
+}

--- a/database/src/main/java/org/akvo/flow/database/upgrade/ResponsesUpgrader.java
+++ b/database/src/main/java/org/akvo/flow/database/upgrade/ResponsesUpgrader.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.akvo.flow.database.upgrade;
+
+import android.database.sqlite.SQLiteDatabase;
+
+import org.akvo.flow.database.DatabaseHelper;
+
+public class ResponsesUpgrader implements DatabaseUpgrader {
+
+    private final DatabaseHelper helper;
+    private final SQLiteDatabase db;
+
+    public ResponsesUpgrader(DatabaseHelper helper, SQLiteDatabase db) {
+        this.helper = helper;
+        this.db = db;
+    }
+
+    @Override
+    public void upgrade() {
+        helper.upgradeFromResponses(db);
+    }
+}

--- a/database/src/main/java/org/akvo/flow/database/upgrade/UpgraderFactory.java
+++ b/database/src/main/java/org/akvo/flow/database/upgrade/UpgraderFactory.java
@@ -49,6 +49,8 @@ public class UpgraderFactory {
                     databaseUpgrader.addUpgrader(new PreferencesUpgrader(helper, db));
                 case DatabaseHelper.VER_LANGUAGES_MIGRATE:
                     databaseUpgrader.addUpgrader(new LanguagesUpgrader(helper, db));
+                case DatabaseHelper.VER_RESPONSE_ITERATION:
+                    databaseUpgrader.addUpgrader(new ResponsesUpgrader(helper, db));
                 default:
                     break;
             }

--- a/database/src/test/java/org/akvo/flow/database/DatabaseHelperTest.java
+++ b/database/src/test/java/org/akvo/flow/database/DatabaseHelperTest.java
@@ -53,7 +53,7 @@ public class DatabaseHelperTest {
     private SQLiteDatabase mockDb;
 
     @Test
-    public void onUpgradeShouldUpgradeCorrectlyIfVersionBeforeLaunch() throws Exception {
+    public void onUpgradeShouldUpgradeCorrectlyIfVersionBeforeLaunch() {
         DatabaseHelper helper = spy(
                 new DatabaseHelper(mockContext, mockLanguageTable, mockMigrationListener));
         doNothing().when(helper).onCreate(any(SQLiteDatabase.class));
@@ -66,7 +66,7 @@ public class DatabaseHelperTest {
     }
 
     @Test
-    public void onUpgradeShouldUpgradeCorrectlyIfVersionLaunch() throws Exception {
+    public void onUpgradeShouldUpgradeCorrectlyIfVersionLaunch() {
         DatabaseHelper helper = spy(
                 new DatabaseHelper(mockContext, mockLanguageTable, mockMigrationListener));
         configureDatabaseHelper(helper);
@@ -80,6 +80,7 @@ public class DatabaseHelperTest {
         verify(helper, times(1)).upgradeFromCaddisfly(mockDb);
         verify(helper, times(1)).upgradeFromPreferences(mockDb);
         verify(helper, times(1)).upgradeFromLanguages(mockDb);
+        verify(helper, times(1)).upgradeFromResponses(mockDb);
     }
 
     private void configureDatabaseHelper(DatabaseHelper helper) {
@@ -90,10 +91,11 @@ public class DatabaseHelperTest {
         doNothing().when(helper).upgradeFromCaddisfly(any(SQLiteDatabase.class));
         doNothing().when(helper).upgradeFromPreferences(any(SQLiteDatabase.class));
         doNothing().when(helper).upgradeFromLanguages(any(SQLiteDatabase.class));
+        doNothing().when(helper).upgradeFromResponses(any(SQLiteDatabase.class));
     }
 
     @Test
-    public void onUpgradeShouldUpgradeCorrectlyIfVersionSubmitter() throws Exception {
+    public void onUpgradeShouldUpgradeCorrectlyIfVersionSubmitter() {
         DatabaseHelper helper = spy(
                 new DatabaseHelper(mockContext, mockLanguageTable, mockMigrationListener));
         configureDatabaseHelper(helper);
@@ -107,10 +109,11 @@ public class DatabaseHelperTest {
         verify(helper, times(1)).upgradeFromCaddisfly(mockDb);
         verify(helper, times(1)).upgradeFromPreferences(mockDb);
         verify(helper, times(1)).upgradeFromLanguages(mockDb);
+        verify(helper, times(1)).upgradeFromResponses(mockDb);
     }
 
     @Test
-    public void onUpgradeShouldUpgradeCorrectlyIfVersionCheck() throws Exception {
+    public void onUpgradeShouldUpgradeCorrectlyIfVersionCheck() {
         DatabaseHelper helper = spy(
                 new DatabaseHelper(mockContext, mockLanguageTable, mockMigrationListener));
         configureDatabaseHelper(helper);
@@ -124,10 +127,11 @@ public class DatabaseHelperTest {
         verify(helper, times(1)).upgradeFromCaddisfly(mockDb);
         verify(helper, times(1)).upgradeFromPreferences(mockDb);
         verify(helper, times(1)).upgradeFromLanguages(mockDb);
+        verify(helper, times(1)).upgradeFromResponses(mockDb);
     }
 
     @Test
-    public void onUpgradeShouldUpgradeCorrectlyIfVersionFormVersion() throws Exception {
+    public void onUpgradeShouldUpgradeCorrectlyIfVersionFormVersion() {
         DatabaseHelper helper = spy(
                 new DatabaseHelper(mockContext, mockLanguageTable, mockMigrationListener));
         configureDatabaseHelper(helper);
@@ -141,10 +145,11 @@ public class DatabaseHelperTest {
         verify(helper, times(1)).upgradeFromCaddisfly(mockDb);
         verify(helper, times(1)).upgradeFromPreferences(mockDb);
         verify(helper, times(1)).upgradeFromLanguages(mockDb);
+        verify(helper, times(1)).upgradeFromResponses(mockDb);
     }
 
     @Test
-    public void onUpgradeShouldUpgradeCorrectlyIfVersionCaddisfly() throws Exception {
+    public void onUpgradeShouldUpgradeCorrectlyIfVersionCaddisfly() {
         DatabaseHelper helper = spy(
                 new DatabaseHelper(mockContext, mockLanguageTable, mockMigrationListener));
         configureDatabaseHelper(helper);
@@ -158,10 +163,11 @@ public class DatabaseHelperTest {
         verify(helper, times(1)).upgradeFromCaddisfly(mockDb);
         verify(helper, times(1)).upgradeFromPreferences(mockDb);
         verify(helper, times(1)).upgradeFromLanguages(mockDb);
+        verify(helper, times(1)).upgradeFromResponses(mockDb);
     }
 
     @Test
-    public void onUpgradeShouldUpgradeCorrectlyIfVersionPreferences() throws Exception {
+    public void onUpgradeShouldUpgradeCorrectlyIfVersionPreferences() {
         DatabaseHelper helper = spy(
                 new DatabaseHelper(mockContext, mockLanguageTable, mockMigrationListener));
         configureDatabaseHelper(helper);
@@ -175,10 +181,11 @@ public class DatabaseHelperTest {
         verify(helper, times(0)).upgradeFromCaddisfly(mockDb);
         verify(helper, times(1)).upgradeFromPreferences(mockDb);
         verify(helper, times(1)).upgradeFromLanguages(mockDb);
+        verify(helper, times(1)).upgradeFromResponses(mockDb);
     }
 
     @Test
-    public void onUpgradeShouldUpgradeCorrectlyIfVersionLanguagesMigrate() throws Exception {
+    public void onUpgradeShouldUpgradeCorrectlyIfVersionLanguagesMigrate() {
         DatabaseHelper helper = spy(
                 new DatabaseHelper(mockContext, mockLanguageTable, mockMigrationListener));
         configureDatabaseHelper(helper);
@@ -192,5 +199,24 @@ public class DatabaseHelperTest {
         verify(helper, times(0)).upgradeFromCaddisfly(mockDb);
         verify(helper, times(0)).upgradeFromPreferences(mockDb);
         verify(helper, times(1)).upgradeFromLanguages(mockDb);
+        verify(helper, times(1)).upgradeFromResponses(mockDb);
+    }
+
+    @Test
+    public void onUpgradeShouldUpgradeCorrectlyIfVersionResponseMigrate() {
+        DatabaseHelper helper = spy(
+                new DatabaseHelper(mockContext, mockLanguageTable, mockMigrationListener));
+        configureDatabaseHelper(helper);
+
+        helper.onUpgrade(mockDb, DatabaseHelper.VER_RESPONSE_ITERATION, DatabaseHelper.DATABASE_VERSION);
+
+        verify(helper, times(0)).upgradeFromLaunch(mockDb);
+        verify(helper, times(0)).upgradeFromFormSubmitter(mockDb);
+        verify(helper, times(0)).upgradeFromFormCheck(mockDb);
+        verify(helper, times(0)).upgradeFromFormVersion(mockDb);
+        verify(helper, times(0)).upgradeFromCaddisfly(mockDb);
+        verify(helper, times(0)).upgradeFromPreferences(mockDb);
+        verify(helper, times(0)).upgradeFromLanguages(mockDb);
+        verify(helper, times(1)).upgradeFromResponses(mockDb);
     }
 }

--- a/database/src/test/java/org/akvo/flow/database/upgrade/UpgraderFactoryTest.java
+++ b/database/src/test/java/org/akvo/flow/database/upgrade/UpgraderFactoryTest.java
@@ -49,7 +49,7 @@ public class UpgraderFactoryTest {
         UpgraderVisitor upgrader = (UpgraderVisitor) upgraderFactory
                 .createUpgrader(DatabaseHelper.VER_LAUNCH, null, null);
 
-        assertEquals(7, upgrader.getUpgraders().size());
+        assertEquals(8, upgrader.getUpgraders().size());
         assertTrue(containsLaunchUpgrader(upgrader.getUpgraders()));
         assertTrue(containsFormSubmitterUpgrader(upgrader.getUpgraders()));
         assertTrue(containsFormCheckUpgrader(upgrader.getUpgraders()));
@@ -57,6 +57,7 @@ public class UpgraderFactoryTest {
         assertTrue(containsCaddisflyUpgrader(upgrader.getUpgraders()));
         assertTrue(containsPreferencesUpgrader(upgrader.getUpgraders()));
         assertTrue(containsLanguagesUpgrader(upgrader.getUpgraders()));
+        assertTrue(containsResponsesUpgrader(upgrader.getUpgraders()));
     }
 
     @Test
@@ -65,7 +66,7 @@ public class UpgraderFactoryTest {
         UpgraderVisitor upgrader = (UpgraderVisitor) upgraderFactory
                 .createUpgrader(DatabaseHelper.VER_FORM_SUBMITTER, null, null);
 
-        assertEquals(6, upgrader.getUpgraders().size());
+        assertEquals(7, upgrader.getUpgraders().size());
         assertFalse(containsLaunchUpgrader(upgrader.getUpgraders()));
         assertTrue(containsFormSubmitterUpgrader(upgrader.getUpgraders()));
         assertTrue(containsFormCheckUpgrader(upgrader.getUpgraders()));
@@ -73,6 +74,7 @@ public class UpgraderFactoryTest {
         assertTrue(containsCaddisflyUpgrader(upgrader.getUpgraders()));
         assertTrue(containsPreferencesUpgrader(upgrader.getUpgraders()));
         assertTrue(containsLanguagesUpgrader(upgrader.getUpgraders()));
+        assertTrue(containsResponsesUpgrader(upgrader.getUpgraders()));
     }
 
     @Test
@@ -81,7 +83,7 @@ public class UpgraderFactoryTest {
         UpgraderVisitor upgrader = (UpgraderVisitor) upgraderFactory
                 .createUpgrader(DatabaseHelper.VER_FORM_DEL_CHECK, null, null);
 
-        assertEquals(5, upgrader.getUpgraders().size());
+        assertEquals(6, upgrader.getUpgraders().size());
         assertFalse(containsLaunchUpgrader(upgrader.getUpgraders()));
         assertFalse(containsFormSubmitterUpgrader(upgrader.getUpgraders()));
         assertTrue(containsFormCheckUpgrader(upgrader.getUpgraders()));
@@ -89,6 +91,7 @@ public class UpgraderFactoryTest {
         assertTrue(containsCaddisflyUpgrader(upgrader.getUpgraders()));
         assertTrue(containsPreferencesUpgrader(upgrader.getUpgraders()));
         assertTrue(containsLanguagesUpgrader(upgrader.getUpgraders()));
+        assertTrue(containsResponsesUpgrader(upgrader.getUpgraders()));
     }
 
     @Test
@@ -97,7 +100,7 @@ public class UpgraderFactoryTest {
         UpgraderVisitor upgrader = (UpgraderVisitor) upgraderFactory
                 .createUpgrader(DatabaseHelper.VER_FORM_VERSION, null, null);
 
-        assertEquals(4, upgrader.getUpgraders().size());
+        assertEquals(5, upgrader.getUpgraders().size());
         assertFalse(containsLaunchUpgrader(upgrader.getUpgraders()));
         assertFalse(containsFormSubmitterUpgrader(upgrader.getUpgraders()));
         assertFalse(containsFormCheckUpgrader(upgrader.getUpgraders()));
@@ -105,6 +108,7 @@ public class UpgraderFactoryTest {
         assertTrue(containsCaddisflyUpgrader(upgrader.getUpgraders()));
         assertTrue(containsPreferencesUpgrader(upgrader.getUpgraders()));
         assertTrue(containsLanguagesUpgrader(upgrader.getUpgraders()));
+        assertTrue(containsResponsesUpgrader(upgrader.getUpgraders()));
     }
 
     @Test
@@ -113,7 +117,7 @@ public class UpgraderFactoryTest {
         UpgraderVisitor upgrader = (UpgraderVisitor) upgraderFactory
                 .createUpgrader(DatabaseHelper.VER_CADDISFLY_QN, null, null);
 
-        assertEquals(3, upgrader.getUpgraders().size());
+        assertEquals(4, upgrader.getUpgraders().size());
         assertFalse(containsLaunchUpgrader(upgrader.getUpgraders()));
         assertFalse(containsFormSubmitterUpgrader(upgrader.getUpgraders()));
         assertFalse(containsFormCheckUpgrader(upgrader.getUpgraders()));
@@ -121,6 +125,7 @@ public class UpgraderFactoryTest {
         assertTrue(containsCaddisflyUpgrader(upgrader.getUpgraders()));
         assertTrue(containsPreferencesUpgrader(upgrader.getUpgraders()));
         assertTrue(containsLanguagesUpgrader(upgrader.getUpgraders()));
+        assertTrue(containsResponsesUpgrader(upgrader.getUpgraders()));
     }
 
     @Test
@@ -129,7 +134,7 @@ public class UpgraderFactoryTest {
         UpgraderVisitor upgrader = (UpgraderVisitor) upgraderFactory
                 .createUpgrader(DatabaseHelper.VER_PREFERENCES_MIGRATE, null, null);
 
-        assertEquals(2, upgrader.getUpgraders().size());
+        assertEquals(3, upgrader.getUpgraders().size());
         assertFalse(containsLaunchUpgrader(upgrader.getUpgraders()));
         assertFalse(containsFormSubmitterUpgrader(upgrader.getUpgraders()));
         assertFalse(containsFormCheckUpgrader(upgrader.getUpgraders()));
@@ -137,13 +142,31 @@ public class UpgraderFactoryTest {
         assertFalse(containsCaddisflyUpgrader(upgrader.getUpgraders()));
         assertTrue(containsPreferencesUpgrader(upgrader.getUpgraders()));
         assertTrue(containsLanguagesUpgrader(upgrader.getUpgraders()));
+        assertTrue(containsResponsesUpgrader(upgrader.getUpgraders()));
     }
 
     @Test
-    public void createUpgraderShouldCreateNoUpgraderWhenLanguages() {
+    public void createUpgraderShouldCreateCorrectUpgraderWhenLanguages() {
         UpgraderFactory upgraderFactory = new UpgraderFactory();
         UpgraderVisitor upgrader = (UpgraderVisitor) upgraderFactory
                 .createUpgrader(DatabaseHelper.VER_LANGUAGES_MIGRATE, null, null);
+
+        assertEquals(2, upgrader.getUpgraders().size());
+        assertFalse(containsLaunchUpgrader(upgrader.getUpgraders()));
+        assertFalse(containsFormSubmitterUpgrader(upgrader.getUpgraders()));
+        assertFalse(containsFormCheckUpgrader(upgrader.getUpgraders()));
+        assertFalse(containsFormVersionUpgrader(upgrader.getUpgraders()));
+        assertFalse(containsCaddisflyUpgrader(upgrader.getUpgraders()));
+        assertFalse(containsPreferencesUpgrader(upgrader.getUpgraders()));
+        assertTrue(containsLanguagesUpgrader(upgrader.getUpgraders()));
+        assertTrue(containsResponsesUpgrader(upgrader.getUpgraders()));
+    }
+
+    @Test
+    public void createUpgraderShouldCreateCorrectUpgraderWhenResponse() {
+        UpgraderFactory upgraderFactory = new UpgraderFactory();
+        UpgraderVisitor upgrader = (UpgraderVisitor) upgraderFactory
+                .createUpgrader(DatabaseHelper.VER_RESPONSE_ITERATION, null, null);
 
         assertEquals(1, upgrader.getUpgraders().size());
         assertFalse(containsLaunchUpgrader(upgrader.getUpgraders()));
@@ -152,14 +175,15 @@ public class UpgraderFactoryTest {
         assertFalse(containsFormVersionUpgrader(upgrader.getUpgraders()));
         assertFalse(containsCaddisflyUpgrader(upgrader.getUpgraders()));
         assertFalse(containsPreferencesUpgrader(upgrader.getUpgraders()));
-        assertTrue(containsLanguagesUpgrader(upgrader.getUpgraders()));
+        assertFalse(containsLanguagesUpgrader(upgrader.getUpgraders()));
+        assertTrue(containsResponsesUpgrader(upgrader.getUpgraders()));
     }
 
     @Test
-    public void createUpgraderShouldCreateNoUpgraderWhenResponseIteration() {
+    public void createUpgraderShouldCreateNoUpgraderWhenTransmissionIteration() {
         UpgraderFactory upgraderFactory = new UpgraderFactory();
         UpgraderVisitor upgrader = (UpgraderVisitor) upgraderFactory
-                .createUpgrader(DatabaseHelper.VER_RESPONSE_ITERATION, null, null);
+                .createUpgrader(DatabaseHelper.VER_TRANSMISSION_ITERATION, null, null);
 
         assertEquals(0, upgrader.getUpgraders().size());
     }
@@ -221,6 +245,16 @@ public class UpgraderFactoryTest {
     private boolean containsLanguagesUpgrader(List<DatabaseUpgrader> upgraders) {
         for (DatabaseUpgrader upgrader : upgraders) {
             if (upgrader instanceof LanguagesUpgrader) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    private boolean containsResponsesUpgrader(List<DatabaseUpgrader> upgraders) {
+        for (DatabaseUpgrader upgrader : upgraders) {
+            if (upgrader instanceof ResponsesUpgrader) {
                 return true;
             }
         }

--- a/database/src/test/java/org/akvo/flow/database/upgrade/UpgraderFactoryTest.java
+++ b/database/src/test/java/org/akvo/flow/database/upgrade/UpgraderFactoryTest.java
@@ -251,7 +251,6 @@ public class UpgraderFactoryTest {
         return false;
     }
 
-
     private boolean containsResponsesUpgrader(List<DatabaseUpgrader> upgraders) {
         for (DatabaseUpgrader upgrader : upgraders) {
             if (upgrader instanceof ResponsesUpgrader) {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Transmission contains absolute full path to media and zip files but this can lead to issues if the file has been moved, in applications with several users... 
#### The solution
We need to save only the file name and rebuild the path since we know where the files are placed. We also need to:
Migrate old transmissions to make sure they contain only filename
Make sure datasync logic uses the new path
Fix tests related to the database migration
When files are missing from the dashboard, we get their full paths, make sure to search only the filename in our database.
Stop updating transmissions after moving private files to public folder
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
