### PR TITLE
Dataprocessing filepath fix (connect #1147)

### DIFF
--- a/app/src/main/java/org/akvo/flow/service/DataSyncService.java
+++ b/app/src/main/java/org/akvo/flow/service/DataSyncService.java
@@ -550,7 +550,7 @@ public class DataSyncService extends IntentService {
 
         if (sendFile(filePath, dir, contentType, isPublic, FILE_UPLOAD_RETRIES)) {
             FlowApi api = new FlowApi(getApplicationContext());
-            switch (api.sendProcessingNotification(formId, action, filePath)) {
+            switch (api.sendProcessingNotification(formId, action, filename)) {
                 case HttpURLConnection.HTTP_OK:
                     status = TransmissionStatus.SYNCED; // Mark everything synced
                     synced = true;


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
The full device file path is being sent to the backend when requesting file processing
#### The solution
Only send the filename
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
