### PR TITLE
Issue/1199 geoshapes auto save (connect #1199)

### DIFF
--- a/app/src/main/java/org/akvo/flow/activity/GeoshapeActivity.java
+++ b/app/src/main/java/org/akvo/flow/activity/GeoshapeActivity.java
@@ -250,6 +250,12 @@ public class GeoshapeActivity extends BackActivity
         return super.onOptionsItemSelected(item);
     }
 
+    @Override
+    public void onBackPressed() {
+        setShapeResult();
+        super.onBackPressed();
+    }
+
     private void setShapeResult() {
         Intent intent = new Intent();
         if (isValidShape()) {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
If user presses back after creating a shape, it gets lost.
#### The solution
When pressing back proceed the same way as with save.
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
