### PR TITLE
Add margin between each option of the question (connect #1225)

### DIFF
--- a/app/src/main/java/org/akvo/flow/ui/view/QuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/QuestionView.java
@@ -88,7 +88,7 @@ public abstract class QuestionView extends LinearLayout implements QuestionInter
         mError = null;
     }
 
-    private int getDimension(int resId) {
+    protected int getDimension(int resId) {
         return (int) getResources().getDimension(resId);
     }
 

--- a/app/src/main/java/org/akvo/flow/ui/view/option/OptionQuestionViewMultiple.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/option/OptionQuestionViewMultiple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Stichting Akvo (Akvo Foundation)
+ * Copyright (C) 2017-2018 Stichting Akvo (Akvo Foundation)
  *
  * This file is part of Akvo Flow.
  *
@@ -27,6 +27,7 @@ import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.TextView;
 
+import org.akvo.flow.R;
 import org.akvo.flow.domain.Option;
 import org.akvo.flow.domain.Question;
 import org.akvo.flow.event.SurveyListener;
@@ -50,7 +51,7 @@ public class OptionQuestionViewMultiple extends OptionQuestionView {
         if (mOptions != null) {
             for (int i = 0; i < mOptions.size(); i++) {
                 Option option = mOptions.get(i);
-                View view = newCheckbox(option);
+                View view = newCheckbox(option, i);
                 mCheckBoxes.add((CheckBox) view);
                 addView(view);
                 view.setEnabled(!isReadOnly());
@@ -59,9 +60,14 @@ public class OptionQuestionViewMultiple extends OptionQuestionView {
         }
     }
 
-    private View newCheckbox(Option option) {
+    private View newCheckbox(Option option, int i) {
         CheckBox box = new CheckBox(getContext());
-        box.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
+        LayoutParams params = new LayoutParams(LayoutParams.MATCH_PARENT,
+                LayoutParams.WRAP_CONTENT);
+        if (i != 0) {
+            params.topMargin = getDimension(R.dimen.small_padding);
+        }
+        box.setLayoutParams(params);
         box.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {

--- a/app/src/main/java/org/akvo/flow/ui/view/option/OptionQuestionViewSingle.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/option/OptionQuestionViewSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Stichting Akvo (Akvo Foundation)
+ * Copyright (C) 2017-2018 Stichting Akvo (Akvo Foundation)
  *
  * This file is part of Akvo Flow.
  *
@@ -27,6 +27,7 @@ import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.TextView;
 
+import org.akvo.flow.R;
 import org.akvo.flow.domain.Option;
 import org.akvo.flow.domain.Question;
 import org.akvo.flow.event.SurveyListener;
@@ -60,7 +61,7 @@ public class OptionQuestionViewSingle extends OptionQuestionView {
             for (int i = 0; i < mOptions.size(); i++) {
                 Option option = mOptions.get(i);
                 View view;
-                view = newRadioButton(option);
+                view = newRadioButton(option, i);
                 mOptionGroup.addView(view);
                 view.setEnabled(!isReadOnly());
                 view.setId(i); // View ID will match option position within the array
@@ -68,10 +69,15 @@ public class OptionQuestionViewSingle extends OptionQuestionView {
         }
     }
 
-    private View newRadioButton(Option option) {
+    private View newRadioButton(Option option, int i) {
         RadioButton rb = new RadioButton(getContext());
-        rb.setLayoutParams(new RadioGroup.LayoutParams(RadioGroup.LayoutParams.MATCH_PARENT,
-                LayoutParams.WRAP_CONTENT));
+        RadioGroup.LayoutParams params = new RadioGroup.LayoutParams(
+                RadioGroup.LayoutParams.MATCH_PARENT,
+                LayoutParams.WRAP_CONTENT);
+        if (i != 0) {
+            params.topMargin = getDimension(R.dimen.small_padding);
+        }
+        rb.setLayoutParams(params);
         rb.setLongClickable(true);
         rb.setOnLongClickListener(new OnLongClickListener() {
             @Override


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
options do not look nice when the text is longer than single line and it hard to know where the next option starts
#### The solution
add padding to help separate the options a bit and make it nicer for the user to chose the right option
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [x] Connect the issue
* [ ] Test plan
* [x] Copyright header
* [x] Code formatting
* [x] Documentation
