### PR TITLE
[#1229] Fixed crash in TimeCheckActivity (connect #1229)

### DIFF
--- a/app/src/main/res/layout/time_check_activity.xml
+++ b/app/src/main/res/layout/time_check_activity.xml
@@ -1,45 +1,30 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:orientation="vertical"
+              android:paddingBottom="@dimen/activity_vertical_margin"
+              android:paddingLeft="@dimen/activity_horizontal_margin"
+              android:paddingRight="@dimen/activity_horizontal_margin"
+              android:paddingTop="@dimen/activity_vertical_margin">
 
     <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@drawable/ab_solid_flow"
-        android:padding="@dimen/activity_horizontal_margin"
-        android:text="@string/time_check_activity"
-        android:textSize="20sp" />
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/activity_vertical_margin"
-        android:paddingLeft="@dimen/activity_horizontal_margin"
-        android:paddingRight="@dimen/activity_horizontal_margin"
-        android:paddingTop="@dimen/activity_vertical_margin">
-
-        <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="8dp"
             android:text="@string/time_warning"
-            android:textSize="18sp" />
+            android:textSize="18sp"/>
 
-        <TextView
+    <TextView
             android:id="@+id/local_time_tv"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="8dp"
-            android:textSize="18sp" />
+            android:textSize="18sp"/>
 
-        <Button
+    <Button
             android:id="@+id/adjust_btn"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             style="@style/PrimaryButtonStyle"
-            android:text="@string/adjust_date" />
-
-    </LinearLayout>
+            android:text="@string/adjust_date"/>
 </LinearLayout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <style name="Flow.Dialog" parent="@android:style/Theme.Dialog">
+    <style name="Flow.Dialog" parent="Theme.AppCompat.Dialog">
         <item name="android:textColor">@color/white</item>
         <item name="android:listViewStyle">@style/Flow.ListView</item>
     </style>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
This is a crash that happens in the app current release and needs to be fixed. It is due to the usage of an old theme
#### The solution
using the new android theme, also removed useless nested layout and duplicated title.
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
