### PR TITLE
[#1232] remove CAMERA permission and make camera hardware not mandatory (connect #1232)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.akvo.flow">
 
-    <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
@@ -16,7 +15,7 @@
     <!-- For GcmTaskService -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
-    <uses-feature android:name="android.hardware.camera"/>
+    <uses-feature android:name="android.hardware.camera" android:required="false"/>
 
     <application
             android:name=".app.FlowApp"

--- a/app/src/main/java/org/akvo/flow/ui/Navigator.java
+++ b/app/src/main/java/org/akvo/flow/ui/Navigator.java
@@ -111,11 +111,13 @@ public class Navigator {
 
     public void navigateToTakePhoto(@NonNull Activity activity, Uri uri) {
         Intent i = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
-        if (i.resolveActivity(activity.getPackageManager()) != null) {
+        PackageManager packageManager = activity.getPackageManager();
+        if (packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY) && i.resolveActivity(
+                packageManager) != null) {
             i.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, uri);
             activity.startActivityForResult(i, ConstantUtil.PHOTO_ACTIVITY_REQUEST);
         } else {
-            Timber.e(new Exception("No app found to take pictures"));
+            Timber.e(new Exception("No camera on device or no app found to take pictures"));
             //TODO: notify user
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 ext {
     compileSdkVersion = 27
     minSdkVersion = 15
-    targetSdkVersion = 21
+    targetSdkVersion = 23
 
     adapterRxJava2Version = "2.3.0"
     butterKnifeVersion = "8.5.1"


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Camera permission in the manifest + camera hardware -> duplicate
#### The solution
Since we use intents, camera permission is not needed.
Note: the tests will probably fail due to the other permissions not been handled.
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
