### PR TITLE
Issue/1261 notifications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
     <uses-feature android:name="android.hardware.camera" android:required="false"/>
 
     <application
+            android:allowBackup="false"
             android:name=".app.FlowApp"
             android:hasCode="true"
             android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/org/akvo/flow/app/FlowApp.java
+++ b/app/src/main/java/org/akvo/flow/app/FlowApp.java
@@ -100,11 +100,12 @@ public class FlowApp extends Application {
         startUpdateService();
         startBootstrapFolderTracker();
         updateLoggingInfo();
-        registerReceiver(new SyncDataReceiver(), new IntentFilter(SyncDataReceiver.CONNECTIVITY_ACTION));
+        registerReceiver(new SyncDataReceiver(),
+                new IntentFilter(SyncDataReceiver.CONNECTIVITY_ACTION));
         saveConfig();
     }
 
-    protected void installLeakCanary() {
+    private void installLeakCanary() {
         LeakCanary.install(this);
     }
 

--- a/app/src/main/java/org/akvo/flow/util/ConstantUtil.java
+++ b/app/src/main/java/org/akvo/flow/util/ConstantUtil.java
@@ -247,6 +247,8 @@ public class ConstantUtil {
     public static final int STORAGE_PERMISSION_CODE = 2;
     public static final int STORAGE_AND_PHONE_STATE_PERMISSION_CODE = 3;
 
+    public static final String NOTIFICATION_CHANNEL_ID = "1";
+
     /**
      * prevent instantiation
      */

--- a/app/src/main/java/org/akvo/flow/util/NotificationHelper.java
+++ b/app/src/main/java/org/akvo/flow/util/NotificationHelper.java
@@ -20,14 +20,18 @@
 package org.akvo.flow.util;
 
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.TaskStackBuilder;
 import android.support.v4.content.ContextCompat;
 
 import org.akvo.flow.R;
+import org.akvo.flow.activity.SurveyActivity;
 
 public class NotificationHelper {
 
@@ -71,13 +75,11 @@ public class NotificationHelper {
     }
 
     public static void displayNotification(Context context, int total, String title, String text,
-            int notificationId,
-            boolean ongoing, int progress) {
+            int notificationId, boolean ongoing, int progress) {
         NotificationCompat.Builder builder = createNotificationBuilder(title, text, context);
 
-        builder.setOngoing(ongoing);// Ongoing if still syncing the records
+        builder.setOngoing(ongoing);
 
-        // Progress will only be displayed in Android versions > 4.0
         builder.setProgress(total, progress, false);
 
         notifyWithDummyIntent(context, notificationId, builder);
@@ -85,21 +87,28 @@ public class NotificationHelper {
 
     public static Notification getSyncingNotification(Context context) {
         String title = context.getString(R.string.sync_service_notification_title);
-        NotificationCompat.Builder b = new NotificationCompat.Builder(context)
+        NotificationCompat.Builder b = new NotificationCompat.Builder(context,
+                ConstantUtil.NOTIFICATION_CHANNEL_ID)
                 .setSmallIcon(R.drawable.notification_icon)
                 .setContentTitle(title)
                 .setTicker(context.getString(R.string.sync_service_notification_ticker))
                 .setProgress(0, 0, true)
                 .setColor(ContextCompat.getColor(context, R.color.orange_main))
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setOngoing(true);
         return (b.build());
     }
 
     private static void notifyWithDummyIntent(Context context, int notificationId,
             NotificationCompat.Builder builder) {
-        // Dummy intent. Do nothing when clicked
-        PendingIntent dummyIntent = PendingIntent.getActivity(context, 0, new Intent(), 0);
-        builder.setContentIntent(dummyIntent);
+        Intent resultIntent = new Intent(context, SurveyActivity.class);
+        TaskStackBuilder stackBuilder = TaskStackBuilder.create(context);
+        stackBuilder.addNextIntentWithParentStack(resultIntent);
+        PendingIntent resultPendingIntent =
+                stackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
+        builder.setContentIntent(resultPendingIntent);
+
+        createNotificationChannel(context);
 
         NotificationManager notificationManager =
                 (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
@@ -114,10 +123,12 @@ public class NotificationHelper {
 
     private static NotificationCompat.Builder createDefaultNotification(String title, String text,
             Context context) {
-        return new NotificationCompat.Builder(context).setSmallIcon(R.drawable.notification_icon)
+        return new NotificationCompat.Builder(context, ConstantUtil.NOTIFICATION_CHANNEL_ID)
+                .setSmallIcon(R.drawable.notification_icon)
                 .setStyle(new NotificationCompat.BigTextStyle().bigText(text))
                 .setContentTitle(title)
                 .setContentText(text)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setTicker(title);
     }
 
@@ -125,5 +136,20 @@ public class NotificationHelper {
             String text, Context context) {
         return createDefaultNotification(title, text, context)
                 .setColor(ContextCompat.getColor(context, R.color.red));
+    }
+
+    private static void createNotificationChannel(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            CharSequence name = context.getString(R.string.channel_name);
+            String description = context.getString(R.string.channel_description);
+            NotificationChannel channel = new NotificationChannel(
+                    ConstantUtil.NOTIFICATION_CHANNEL_ID, name,
+                    NotificationManager.IMPORTANCE_DEFAULT);
+            channel.setDescription(description);
+            channel.enableVibration(false);
+            NotificationManager notificationManager = context
+                    .getSystemService(NotificationManager.class);
+            notificationManager.createNotificationChannel(channel);
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -308,5 +308,7 @@
     <string name="action_enable">Enable</string>
     <string name="storage_permission_missing">Storage permission is necessary for the app to work correctly.</string>
     <string name="survey_permissions_missing">Storage and Phone State permissions are necessary for the app to work correctly.</string>
+    <string name="channel_name">Flow channel</string>
+    <string name="channel_description">Flow notifications</string>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 ext {
     compileSdkVersion = 27
     minSdkVersion = 15
-    targetSdkVersion = 24
+    targetSdkVersion = 26
 
     adapterRxJava2Version = "2.3.0"
     butterKnifeVersion = "8.5.1"

--- a/data/src/main/AndroidManifest.xml
+++ b/data/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
           package="org.akvo.flow.data">
 
     <application
-            android:allowBackup="true"
-            android:supportsRtl="true">
-    </application>
+            android:allowBackup="false"
+            android:supportsRtl="true"/>
 
 </manifest>

--- a/database/src/main/AndroidManifest.xml
+++ b/database/src/main/AndroidManifest.xml
@@ -1,10 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.akvo.flow.database">
 
-    <application android:allowBackup="true"
-                 android:supportsRtl="true"
-    >
-
-    </application>
+    <application android:allowBackup="false"
+                 android:supportsRtl="true"/>
 
 </manifest>

--- a/domain/src/main/AndroidManifest.xml
+++ b/domain/src/main/AndroidManifest.xml
@@ -5,8 +5,7 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
 
     <application
-            android:allowBackup="true"
-            android:supportsRtl="true">
-    </application>
+            android:allowBackup="false"
+            android:supportsRtl="true"/>
 
 </manifest>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
App needs to be upgraded to use targetSdk 26
#### The solution
first part is to update the notifications channels otherwise the notifications are not shown:
upgrade target sdk to 26
added android:allowBackup="false" since when reinstalling the app now all the configuration is kept. Since this is not previous behavior disabling until we decide what to do.
remove 
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
