### PR TITLE
[#1318] fix all photo questions seem to be mandatory

### DIFF
--- a/app/src/main/java/org/akvo/flow/ui/view/media/photo/PhotoQuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/media/photo/PhotoQuestionView.java
@@ -263,9 +263,11 @@ public class PhotoQuestionView extends QuestionView implements
 
     @Override
     public boolean isValid() {
-        File file = rebuildFilePath();
-        if (file == null|| !file.exists()) {
-            return false;
+        if (getQuestion().isMandatory()) {
+            File file = rebuildFilePath();
+            if (file == null|| !file.exists()) {
+                return false;
+            }
         }
         return super.isValid();
     }


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
unable to submit even if photo question is not mandatory
#### The solution
fixes all photos are mandatory by checking valid file only if mandatory question
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
