### PR TITLE
[#1346] move 2 strings to non translatable ones

### DIFF
--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -5,4 +5,6 @@
     <string name="sentry_dsn">https://3c2f0307fa7649de95bce7c9b1ccc486:27546384199147b78d15aba2e6b31e6b@sentry.io/141161</string>
 
     <string name="repeated_group_title" translatable="false">%1$s - %2$d</string>
+    <string name="channel_name" translatable="false">Flow channel</string>
+    <string name="channel_description" translatable="false">Flow notifications</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -307,9 +307,6 @@
     <string name="action_enable">Enable</string>
     <string name="storage_permission_missing">Storage permission is necessary for the app to work correctly.</string>
     <string name="survey_permissions_missing">Storage and Phone State permissions are necessary for the app to work correctly.</string>
-    <string name="channel_name">Flow channel</string>
-    <string name="channel_description">Flow notifications</string>
-
 
     <string name="unpublish_service_notification_title">Deleting published files</string>
     <string name="unpublish_service_notification_ticker">Deleting</string>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
NA
#### The solution
These 2 strings do not need to be translated as they serve to identify the channel and other apps do not translate them either. Only affects devices 8.0 ++
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
