### PR TITLE
[#1355] fix crash related to uri permission on newest android devices (Connect #1355)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
     <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES"/>
     <!-- For GcmTaskService -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>

--- a/app/src/main/java/org/akvo/flow/ui/Navigator.java
+++ b/app/src/main/java/org/akvo/flow/ui/Navigator.java
@@ -26,10 +26,12 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.content.FileProvider;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 
@@ -321,9 +323,17 @@ public class Navigator {
      */
     public void installAppUpdate(Context context, String filename) {
         Intent intent = new Intent(Intent.ACTION_VIEW);
-        intent.setDataAndType(Uri.fromFile(new File(filename)),
-                "application/vnd.android.package-archive");
-        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        Uri fileUri;
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            fileUri = FileProvider
+                    .getUriForFile(context, ConstantUtil.FILE_PROVIDER_AUTHORITY,
+                            new File(filename));
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        } else {
+            fileUri = Uri.fromFile(new File(filename));
+        }
+        intent.setDataAndType(fileUri, "application/vnd.android.package-archive");
         context.startActivity(intent);
     }
 

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <files-path path="akvoflow/data/media/" name="videos" />
+    <external-files-path path="apk/" name="apk" />
     <external-path path="Pictures/" name="pictures" />
 </paths>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
crash when user tries to install app update
#### The solution
fix crash related to uri permission
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
