### PR TITLE
[#1368] fix tests on older android devices

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -120,6 +120,7 @@ android {
             proguardFile 'proguard-files/proguard-square-retrofit.pro'
             proguardFile 'proguard-files/proguard-support-v7-appcompat.pro'
             proguardFile getDefaultProguardFile('proguard-android.txt')
+            multiDexKeepProguard file('proguard-files/proguard-multidex-rules.pro')
         }
     }
 
@@ -188,16 +189,6 @@ private static String getBuildYear() {
 android.applicationVariants.all { variant ->
     variant.outputs.all { output ->
         outputFileName = file("/flow.apk")
-    }
-}
-
-configurations.all { config ->
-    if (config.name.contains('UnitTest') || config.name.contains('AndroidTest')) {
-        config.resolutionStrategy.eachDependency { details ->
-            if (details.requested.group == 'com.squareup.leakcanary' && details.requested.name == 'leakcanary-android') {
-                details.useTarget(group: details.requested.group, name: 'leakcanary-android-no-op', version: details.requested.version)
-            }
-        }
     }
 }
 

--- a/app/proguard-files/proguard-multidex-rules.pro
+++ b/app/proguard-files/proguard-multidex-rules.pro
@@ -1,0 +1,6 @@
+-keep @org.junit.runner.RunWith public class *
+-keep class android.support.test.internal** { *; }
+-keep class org.junit.** { *; }
+-keep public class org.akvo.flow.activity.** { *; }
+-keep public class org.akvo.flow.serialization.** { *; }
+-keep public class org.akvo.flow.ui.** { *; }


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
While working on migrating to jetpack, I have realised the ui tests do no work on android 4 but turns out they already did not work before that.
#### The solution
fix the tests on Android 4 (due to multidex)
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
