### PR TITLE
[#1379]Switch to https, since S3 no longer accepts http.

### DIFF
--- a/util/upload-apk/src/main/java/org/akvo/flow/deploy/Deploy.java
+++ b/util/upload-apk/src/main/java/org/akvo/flow/deploy/Deploy.java
@@ -78,7 +78,7 @@ public class Deploy {
         final String version = args[VERSION];
 
         final String s3Path = "apk/" + instance + "/" + file.getName();
-        final String s3Url = "http://akvoflow.s3.amazonaws.com/apk/" + instance + '/'
+        final String s3Url = "https://akvoflow.s3.amazonaws.com/apk/" + instance + '/'
                 + file.getName();
         final String host = instance + ".appspot.com";
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
S3 stopped liking http
#### The solution
store the URL in the datastore as https:
#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
