### PR TITLE
[#1406] Save & restore question details, Set result after tab is loaded

### DIFF
--- a/app/src/main/java/org/akvo/flow/ui/adapter/SurveyTabAdapter.java
+++ b/app/src/main/java/org/akvo/flow/ui/adapter/SurveyTabAdapter.java
@@ -47,6 +47,15 @@ public class SurveyTabAdapter extends PagerAdapter implements ViewPager.OnPageCh
     private List<QuestionGroup> mQuestionGroups;
     private List<QuestionGroupTab> mQuestionGroupTabs;
     private SubmitTab mSubmitTab;
+    private OnTabLoadedListener mOnTabLoadedListener;
+
+    public interface OnTabLoadedListener {
+        void OnTabLoaded();
+    }
+
+    public void setOnTabLoadedListener(OnTabLoadedListener listener) {
+        mOnTabLoadedListener = listener;
+    }
 
     public SurveyTabAdapter(Context context, ViewPager pager, SurveyListener surveyListener,
             QuestionInteractionListener questionListener) {
@@ -88,6 +97,10 @@ public class SurveyTabAdapter extends PagerAdapter implements ViewPager.OnPageCh
             tab.load();
             tab.loadState();
             setupDependencies();// Dependencies might occur across tabs
+
+            if (mOnTabLoadedListener != null) {
+                mOnTabLoadedListener.OnTabLoaded();
+            }
         }
     }
 

--- a/app/src/main/java/org/akvo/flow/util/ConstantUtil.java
+++ b/app/src/main/java/org/akvo/flow/util/ConstantUtil.java
@@ -125,6 +125,7 @@ public class ConstantUtil {
     public static final String FORM_SUBTITLE_EXTRA = "subtitle";
     public static final String QUESTION_ID_EXTRA = "question_id";
     public static final String VIEW_USER_EXTRA = "view_user";
+    public static final String REQUEST_QUESTION_ID_EXTRA = "request_question_id";
 
     /**
      * intents


### PR DESCRIPTION
**Fixes** #1406 & https://github.com/akvo/akvo-caddisfly/issues/235

#### Before the PR (what is the issue or what needed to be done)
On low memory devices, Android sometimes kills the calling activity. Due to this, the result returned from the external activity could be lost. The question details needed to be saved and restored so that the result could be associated with the question correctly.

#### The solution
1. Save the question details in onSaveInstanceState and restore from savedInstanceState
1. Also wait for Survey Tab to be reloaded before setting the result

#### Screenshots (if appropriate)
NA

#### Test Plan
1. Turn on 'Don't keep activities' in Android Developer settings
1. Test that Caddisfly, Photo, Video, Gallery, Barcode, Shape & Signature questions work correctly

#### Reviewer Checklist
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
