### PR TITLE
[#1425] part2 of abstracting maps away from the presentation layer

### DIFF
--- a/app/src/main/res/layout/fragment_map_box_map.xml
+++ b/app/src/main/res/layout/fragment_map_box_map.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.datapoints.map.DataPointsMapFragment">
+
+    <org.akvo.flow.offlinemaps.presentation.MapBoxMapViewImpl
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        style="@style/Base.Widget.AppCompat.ProgressBar.Horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="4dp"
+        android:indeterminate="true"
+        android:indeterminateDrawable="@drawable/blue_horizontal_progress_background"
+        android:visibility="invisible" />
+
+    <org.akvo.flow.offlinemaps.presentation.OfflineMapsFloatingActionButton
+        android:id="@+id/offline_maps_fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start|top"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginBottom="16dp"
+        android:clickable="true"
+        android:visibility="gone"
+        app:backgroundTint="@color/white"
+        app:srcCompat="@drawable/ic_offline_maps" />
+
+</FrameLayout>

--- a/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/Constants.java
+++ b/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/Constants.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.akvo.flow.offlinemaps;
+
+import com.mapbox.mapboxsdk.maps.Style;
+
+public class Constants {
+
+    public static final String MAPBOX_MAP_STYLE = Style.MAPBOX_STREETS;
+    public static final int MAP_BOX_ZOOM_MAX = 2;
+}

--- a/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/MapBoxMapPresenter.java
+++ b/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/MapBoxMapPresenter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.akvo.flow.offlinemaps.presentation;
+
+import org.akvo.flow.offlinemaps.domain.entity.MapInfo;
+import org.akvo.flow.offlinemaps.domain.interactor.GetSelectedOfflineMapInfo;
+
+import javax.inject.Inject;
+
+import io.reactivex.observers.DisposableMaybeObserver;
+import timber.log.Timber;
+
+public class MapBoxMapPresenter {
+
+    private final GetSelectedOfflineMapInfo getSelectedOfflineMapInfo;
+
+    private MapboxMapView view;
+
+    @Inject
+    public MapBoxMapPresenter(GetSelectedOfflineMapInfo getSelectedOfflineMapInfo) {
+        this.getSelectedOfflineMapInfo = getSelectedOfflineMapInfo;
+    }
+
+    public void setView(MapboxMapView mapboxMapView) {
+        this.view = mapboxMapView;
+    }
+
+    public void loadOfflineSettings() {
+        getSelectedOfflineMapInfo.execute(new DisposableMaybeObserver<MapInfo>() {
+            @Override
+            public void onSuccess(MapInfo mapInfo) {
+                view.displayOfflineMap(mapInfo);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                Timber.e(e);
+                view.displayUserLocation();
+            }
+
+            @Override
+            public void onComplete() {
+                view.displayUserLocation();
+            }
+        });
+    }
+
+    public void destroy() {
+        getSelectedOfflineMapInfo.dispose();
+    }
+}

--- a/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/OfflineMapsFloatingActionButton.java
+++ b/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/OfflineMapsFloatingActionButton.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.akvo.flow.offlinemaps.presentation;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+import org.akvo.flow.offlinemaps.R;
+import org.akvo.flow.offlinemaps.presentation.dialog.OfflineMapsDialog;
+
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentActivity;
+
+public class OfflineMapsFloatingActionButton extends FloatingActionButton {
+
+    public OfflineMapsFloatingActionButton(Context context) {
+        this(context, null);
+    }
+
+    public OfflineMapsFloatingActionButton(Context context, AttributeSet attrs) {
+        this(context, attrs, R.attr.floatingActionButtonStyle);
+    }
+
+    public OfflineMapsFloatingActionButton(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context);
+    }
+
+    private void init(Context context) {
+        setOnClickListener(v -> {
+            DialogFragment dialogFragment = OfflineMapsDialog.newInstance();
+            dialogFragment
+                    .show(((FragmentActivity) context).getSupportFragmentManager(),
+                            OfflineMapsDialog.TAG);
+        });
+    }
+}

--- a/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/download/OfflineMapDownloadActivity.java
+++ b/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/download/OfflineMapDownloadActivity.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.akvo.flow.offlinemaps.presentation.download;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.TextWatcher;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ProgressBar;
+
+import com.mapbox.mapboxsdk.geometry.LatLngBounds;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
+
+import org.akvo.flow.offlinemaps.R;
+import org.akvo.flow.offlinemaps.di.DaggerOfflineFeatureComponent;
+import org.akvo.flow.offlinemaps.di.OfflineFeatureModule;
+import org.akvo.flow.offlinemaps.presentation.ToolBarBackActivity;
+import org.akvo.flow.offlinemaps.presentation.list.OfflineAreasListActivity;
+
+import javax.inject.Inject;
+
+import androidx.annotation.Nullable;
+
+public class OfflineMapDownloadActivity extends ToolBarBackActivity
+        implements OfflineMapDownloadView {
+
+    private MapView mapView;
+    private Button saveBt;
+    private EditText mapNameEt;
+    private ProgressBar downloadProgress;
+    private MapboxMap mapboxMap;
+
+    @Inject
+    OfflineMapDownloadPresenter presenter;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_offline_map_download);
+        initialiseInjector();
+        setupToolBar();
+        setUpViews();
+        setupMap(savedInstanceState);
+        presenter.setView(this);
+    }
+
+    private void initialiseInjector() {
+        DaggerOfflineFeatureComponent
+                .builder()
+                .offlineFeatureModule(new OfflineFeatureModule(getApplication()))
+                .build()
+                .inject(this);
+    }
+
+    private void setupMap(Bundle savedInstanceState) {
+        mapView = findViewById(R.id.mapView);
+        mapView.onCreate(savedInstanceState);
+        mapView.getMapAsync(this::setUpMapBox);
+    }
+
+    private void setUpViews() {
+        saveBt = findViewById(R.id.offline_map_save_button);
+        saveBt.setOnClickListener(v -> {
+            if (mapboxMap != null && mapboxMap.getStyle() != null) {
+                float pixelRatio = getResources().getDisplayMetrics().density;
+                String styleUrl = mapboxMap.getStyle().getUrl();
+                LatLngBounds bounds = mapboxMap.getProjection().getVisibleRegion().latLngBounds;
+                double zoom = mapboxMap.getCameraPosition().zoom;
+                presenter.downloadArea(styleUrl, bounds, pixelRatio, zoom,
+                        mapNameEt.getText().toString());
+            }
+        });
+        mapNameEt = findViewById(R.id.offline_map_name);
+        mapNameEt.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count,
+                    int after) {
+                //EMPTY
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                //EMPTY
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                if (TextUtils.isEmpty(mapNameEt.getText().toString())) {
+                    saveBt.setEnabled(false);
+                } else {
+                    saveBt.setEnabled(true);
+                }
+            }
+        });
+        downloadProgress = findViewById(R.id.offline_map_download_progress);
+    }
+
+    private void setUpMapBox(MapboxMap mapboxMap) {
+        this.mapboxMap = mapboxMap;
+        mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
+            //EMPTY
+        });
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        mapView.onStart();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        mapView.onResume();
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        mapView.onPause();
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        mapView.onStop();
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        mapView.onSaveInstanceState(outState);
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        mapView.onDestroy();
+        presenter.destroy();
+    }
+
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        mapView.onLowMemory();
+    }
+
+    @Override
+    public void showProgress() {
+        saveBt.setEnabled(false);
+        downloadProgress.setVisibility(View.VISIBLE);
+    }
+
+    @Override
+    public void navigateToMapsList() {
+        navigateToOfflineAreasList(this);
+        finish();
+    }
+
+    @Override
+    public void showOfflineAreaError() {
+        downloadProgress.setVisibility(View.GONE);
+        saveBt.setEnabled(true);
+        displaySnackBar(downloadProgress, R.string.offline_map_create_error);
+    }
+
+    public void navigateToOfflineAreasList(@Nullable Context context) {
+        if (context != null) {
+            Intent intent = new Intent(context, OfflineAreasListActivity.class);
+            context.startActivity(intent);
+        }
+    }
+}


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
NA
#### The solution
part2 of abstracting maps. All the mapbox related code is moved to offlinemaps module
final solution https://github.com/akvo/akvo-flow-mobile/pull/1425
this part will probably not compile as some classes are missing
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
