### PR TITLE
[#1445] fixed crash when offline

### DIFF
--- a/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/MapBoxMapItemListViewImpl.java
+++ b/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/MapBoxMapItemListViewImpl.java
@@ -307,7 +307,9 @@ public class MapBoxMapItemListViewImpl extends MapView implements OnMapReadyCall
     }
 
     public void displayDataPoints(FeatureCollection featureCollection) {
-        source.setGeoJson(featureCollection);
+        if (source != null) {
+            source.setGeoJson(featureCollection);
+        }
         selectionManager.unSelectFeature();
     }
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
NA
#### The solution
When switching surveys in offline mode, the mabox map made the app crash. Added a Null check. Due to the crash the window displaying the previous datapoint also did not get dismissed
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
