### PR TITLE
[#1458] fix geoshape activity crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,10 @@
         android:usesCleartextTraffic="true"
         tools:ignore="GoogleAppIndexingWarning">
 
+        <uses-library
+            android:name="org.apache.http.legacy"
+            android:required="false" />
+
         <meta-data
             android:name="io.fabric.ApiKey"
             android:value="89dc21727e76a10511ecda549cab1b2d3aff2ec7" />


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Crash when trying to fill a goeshape question with and and Android 9.0 device
#### The solution
Applied the fix suggested https://stackoverflow.com/questions/50782806/android-google-maps-java-lang-noclassdeffounderror-failed-resolution-of-lorg-a
Crash no longer happens
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
