### PR TITLE
[#1447] initial geoshape and mapbox related classes

### DIFF
--- a/app/src/main/java/org/akvo/flow/presentation/geoshape/LengthCounter.java
+++ b/app/src/main/java/org/akvo/flow/presentation/geoshape/LengthCounter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.akvo.flow.presentation.geoshape;
+
+import android.location.Location;
+
+import com.mapbox.geojson.Point;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+public class LengthCounter {
+
+    @Inject
+    public LengthCounter() {
+    }
+
+    public float computeLength(List<Point> points) {
+        float length = 0f;
+        Point previous = null;
+        for (Point point : points) {
+            if (previous != null) {
+                float[] distance = new float[1];
+                Location.distanceBetween(previous.latitude(), previous.longitude(),
+                        point.latitude(), point.longitude(), distance);
+                length += distance[0];
+            }
+            previous = point;
+        }
+        return length;
+    }
+}

--- a/app/src/main/java/org/akvo/flow/presentation/geoshape/create/CoordinatesMapper.java
+++ b/app/src/main/java/org/akvo/flow/presentation/geoshape/create/CoordinatesMapper.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.akvo.flow.presentation.geoshape.create;
+
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+public class CoordinatesMapper {
+
+    @Inject
+    public CoordinatesMapper() {
+    }
+
+    List<LatLng> toLatLng(List<Point> coordinates) {
+        List<LatLng> latLngs = new ArrayList<>();
+        for (Point p : coordinates) {
+            LatLng latLng = new LatLng(p.latitude(), p.longitude());
+            latLngs.add(latLng);
+        }
+        return latLngs;
+    }
+}

--- a/app/src/main/java/org/akvo/flow/presentation/geoshape/create/DrawMode.java
+++ b/app/src/main/java/org/akvo/flow/presentation/geoshape/create/DrawMode.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.akvo.flow.presentation.geoshape.create;
+
+public enum DrawMode {
+    NONE,
+    POINT,
+    LINE,
+    AREA
+}

--- a/app/src/main/res/menu/create_geoshape_activity_bottom.xml
+++ b/app/src/main/res/menu/create_geoshape_activity_bottom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/shape_info"
+        android:icon="@drawable/ic_info_path"
+        android:visible="true"
+        app:showAsAction="always"
+        android:title="@string/geoshape_bottom_item_info" />
+    <item
+        android:id="@+id/add_point"
+        android:icon="@drawable/ic_add_point"
+        android:visible="true"
+        app:showAsAction="always"
+        android:title="@string/geoshape_bottom_item_add_point" />
+    <item
+        android:id="@+id/delete_point"
+        android:icon="@drawable/ic_delete_point"
+        android:visible="true"
+        app:showAsAction="always"
+        android:title="@string/geoshape_bottom_item_delete_point" />
+    <item
+        android:id="@+id/delete_feature"
+        android:icon="@drawable/ic_delete_feature"
+        android:visible="true"
+        app:showAsAction="always"
+        android:title="@string/geoshape_bottom_item_delete_feature" />
+</menu>

--- a/offlinemaps/src/main/AndroidManifest.xml
+++ b/offlinemaps/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application>
         <activity

--- a/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/geoshapes/GeoShapeConstants.java
+++ b/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/geoshapes/GeoShapeConstants.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.akvo.flow.offlinemaps.presentation.geoshapes;
+
+public class GeoShapeConstants {
+    public static final String CIRCLE_SOURCE_ID = "circle-source-id";
+    public static final String FILL_SOURCE_ID = "fill-source-id";
+    public static final String LINE_SOURCE_ID = "line-source-id";
+    public static final String CIRCLE_LAYER_ID = "unselected-point-layer-id";
+    public static final String SELECTED_POINT_LAYER_ID = "selected-point-layer-id";
+    public static final String SELECTED_POINT_TEXT_LAYER_ID = "selected-point-text-layer-id";
+    public static final String SELECTED_FEATURE_POINT_LAYER_ID = "selected-feature-point-layer-id";
+    public static final String FILL_LAYER_ID = "fill-layer-polygon-id";
+    public static final String LINE_LAYER_ID = "line-layer-id";
+    public static final int FILL_COLOR = 0x88736357;
+    public static final int LINE_COLOR = 0xEE736357;
+    public static final int CIRCLE_COLOR = 0xFF736357;
+    public static final int CIRCLE_LINE_COLOR = 0xFF5B5048;
+    public static final int ANIMATION_DURATION_MS = 400;
+    public static final int ONE_POINT_ZOOM = 12;
+    public static final float ACCURACY_THRESHOLD = 20f;
+    public static final int SELECTED_SHAPE_COLOR = 0xFFE27C00;
+    public static final int SELECTED_SHAPE_BORDER_COLOR = 0xFFA65E07;
+    public static final int SELECTED_POINT_COLOR = 0xFF00A79D;
+    public static final int SELECTED_POINT_BORDER_COLOR = 0xFF027A73;
+    public static final String FEATURE_LINE = "is-line";
+    public static final String FEATURE_POINT = "is-point";
+    public static final String FEATURE_POLYGON = "is-polygon";
+    public static final String POINT_SELECTED_PROPERTY = "is-point-selected";
+    public static final String SHAPE_SELECTED_PROPERTY = "is-shape-selected";
+    public static final String LAT_LNG_PROPERTY = "lat-lng";
+}

--- a/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/geoshapes/GeoShapesClickListener.java
+++ b/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/geoshapes/GeoShapesClickListener.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.akvo.flow.offlinemaps.presentation.geoshapes;
+
+import com.mapbox.geojson.Feature;
+
+public interface GeoShapesClickListener {
+
+    boolean onGeoShapeSelected(Feature feature);
+}

--- a/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/geoshapes/GeoShapesMapPresenter.java
+++ b/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/geoshapes/GeoShapesMapPresenter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.akvo.flow.offlinemaps.presentation.geoshapes;
+
+import com.mapbox.mapboxsdk.geometry.LatLng;
+
+import org.akvo.flow.offlinemaps.domain.entity.MapInfo;
+import org.akvo.flow.offlinemaps.domain.interactor.GetSelectedOfflineMapInfo;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import io.reactivex.observers.DisposableMaybeObserver;
+import timber.log.Timber;
+
+public class GeoShapesMapPresenter {
+
+    private final GetSelectedOfflineMapInfo getSelectedOfflineMapInfo;
+
+    private GeoShapesMapView view;
+
+    @Inject
+    public GeoShapesMapPresenter(GetSelectedOfflineMapInfo getSelectedOfflineMapInfo) {
+        this.getSelectedOfflineMapInfo = getSelectedOfflineMapInfo;
+    }
+
+    public void setView(GeoShapesMapView view) {
+        this.view = view;
+    }
+
+    public void loadOfflineSettings(List<LatLng> listOfCoordinates) {
+        getSelectedOfflineMapInfo.execute(new DisposableMaybeObserver<MapInfo>() {
+            @Override
+            public void onSuccess(MapInfo mapInfo) {
+                view.centerOnOfflineArea(mapInfo);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                Timber.e(e);
+                view.centerOnCoordinates(listOfCoordinates);
+            }
+
+            @Override
+            public void onComplete() {
+                view.centerOnCoordinates(listOfCoordinates);
+            }
+        });
+    }
+
+    public void destroy() {
+        getSelectedOfflineMapInfo.dispose();
+    }
+}

--- a/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/geoshapes/GeoShapesMapView.java
+++ b/offlinemaps/src/main/java/org/akvo/flow/offlinemaps/presentation/geoshapes/GeoShapesMapView.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.akvo.flow.offlinemaps.presentation.geoshapes;
+
+import com.mapbox.mapboxsdk.geometry.LatLng;
+
+import org.akvo.flow.offlinemaps.domain.entity.MapInfo;
+
+import java.util.List;
+
+public interface GeoShapesMapView {
+
+    void centerOnCoordinates(List<LatLng> listOfCoordinates);
+
+    void centerOnOfflineArea(MapInfo mapInfo);
+}

--- a/uicomponents/src/main/res/values/strings.xml
+++ b/uicomponents/src/main/res/values/strings.xml
@@ -340,6 +340,18 @@
     <string name="offline_item_delete_dialog_title">Delete map?</string>
     <string name="offline_item_delete_dialog_message">%1$s will no longer be available for use</string>
 
+    <string name="geoshape_bottom_item_info">Info</string>
+    <string name="geoshape_bottom_item_add_point">Add point</string>
+    <string name="geoshape_bottom_item_delete_point">Delete point</string>
+    <string name="geoshape_bottom_item_delete_feature">Delete feature</string>
+
+    <string name="geoshapes_error_manual_disabled">Manual input is disabled for this question</string>
+    <string name="geoshapes_error_select_shape">Please select at least one shape in the menu</string>
+    <string name="geoshape_properties_point_count">Point Count: %1$s</string>
+    <string name="geoshape_properties_length">Length: %1$s</string>
+    <string name="geoshape_properties_area">Area: %1$s</string>
+    <string name="geoshape_properties_title">Properties</string>
+
     <plurals name="download_forms_error">
         <item quantity="one">Error downloading form</item>
         <item quantity="other">Error downloading forms</item>
@@ -348,5 +360,4 @@
         <item quantity="one">Form downloaded</item>
         <item quantity="other">Forms downloaded</item>
     </plurals>
-
 </resources>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Geoshapes use google maps, offline areas cannot be used.
#### The solution
Part 1 of Creating geoshapes using the mapbox library
Added base classes for the app module (utility classes)
Added one bottom menu item
Added mabox and geoshape related classes
final solution https://github.com/akvo/akvo-flow-mobile/pull/1471
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
