### PR TITLE
[#1489] added missing permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <uses-feature
         android:name="android.hardware.camera"


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
There is a crash on Android 9 or 10 devices when we try to start a foreground service (the one that deletes files after publishing them
#### The solution
Add the missing permission to manifest
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
