### PR TITLE
[#1545] add sampling to 0.75 for sentry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ util/scripts/temp.md
 captures/
 
 #sentry config files
-sentry.properties
+/sentry.properties
 
 #CI config
 build_config

--- a/app/src/main/resources/sentry.properties
+++ b/app/src/main/resources/sentry.properties
@@ -1,0 +1,1 @@
+sample.rate=0.75


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
All crashes and exceptions are sent to sentry
#### The solution
sample to 0.75 so only about 75% will be sent
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header
* [ ] Formatted the code per our style guide
* [ ] Added a documentation (if relevant)
