### PR TITLE
[#1555] added a "fix" for the question group bug

### DIFF
--- a/app/src/androidTest/java/org/akvo/flow/activity/form/data/SurveyInstaller.java
+++ b/app/src/androidTest/java/org/akvo/flow/activity/form/data/SurveyInstaller.java
@@ -166,6 +166,15 @@ public class SurveyInstaller {
         };
     }
 
+    @NonNull
+    public static QuestionResponse.QuestionResponseBuilder[] generatePartialRepeatedGroupResponseData() {
+        return new QuestionResponse.QuestionResponseBuilder[] {
+                generateResponse("text-response-rep-one", ConstantUtil.VALUE_RESPONSE_TYPE, "205929118", 0),
+                generateResponse("1234567", ConstantUtil.VALUE_RESPONSE_TYPE, "205929119", 0),
+                generateResponse("text-response-rep-two", ConstantUtil.VALUE_RESPONSE_TYPE, "205929118", 1),
+        };
+    }
+
     public void clearSurveys() {
         for (File file : surveyFiles) {
             file.delete();

--- a/app/src/androidTest/java/org/akvo/flow/activity/form/formsview/RepeatedGroupFormViewTest.kt
+++ b/app/src/androidTest/java/org/akvo/flow/activity/form/formsview/RepeatedGroupFormViewTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.akvo.flow.activity.form.formsview
+
+import android.Manifest
+import android.content.Intent
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import androidx.test.rule.ActivityTestRule
+import androidx.test.rule.GrantPermissionRule
+import org.akvo.flow.R
+import org.akvo.flow.activity.FormActivity
+import org.akvo.flow.activity.form.FormActivityTestUtil.getFormActivityIntent
+import org.akvo.flow.activity.form.FormActivityTestUtil.verifyRepeatHeaderText
+import org.akvo.flow.activity.form.FormActivityTestUtil.withQuestionViewParent
+import org.akvo.flow.activity.form.data.SurveyInstaller
+import org.akvo.flow.activity.form.data.SurveyInstaller.generatePartialRepeatedGroupResponseData
+import org.akvo.flow.activity.form.data.SurveyRequisite
+import org.akvo.flow.tests.R.raw.repeated_one_group_form_2questions
+import org.akvo.flow.ui.view.FreetextQuestionView
+import org.akvo.flow.ui.view.barcode.BarcodeQuestionViewSingle
+import org.hamcrest.CoreMatchers.allOf
+import org.junit.AfterClass
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@MediumTest
+@RunWith(AndroidJUnit4::class)
+class RepeatedGroupFormViewTest {
+
+    @get:Rule
+    var permissionRule: GrantPermissionRule = GrantPermissionRule.grant(
+        Manifest.permission.ACCESS_FINE_LOCATION,
+        Manifest.permission.WRITE_EXTERNAL_STORAGE,
+        Manifest.permission.READ_PHONE_STATE
+    )
+
+    @get:Rule
+    var rule: ActivityTestRule<FormActivity> = object : ActivityTestRule<FormActivity>(
+        FormActivity::class.java
+    ) {
+        override fun getActivityIntent(): Intent {
+            val targetContext = getInstrumentation().targetContext
+            SurveyRequisite.setRequisites(targetContext)
+            val installer = SurveyInstaller(targetContext)
+            val survey =
+                installer.installSurvey(
+                    repeated_one_group_form_2questions,
+                    getInstrumentation().context
+                )
+            val id =
+                installer.createDataPoint(
+                    survey.surveyGroup,
+                    *generatePartialRepeatedGroupResponseData()
+                ).first!!
+            return getFormActivityIntent(207569117L, "200389118", SURVEY_TITLE, id, false)
+        }
+    }
+
+    companion object {
+
+        private const val SURVEY_TITLE = "RepeatedGroup"
+
+        @AfterClass
+        fun afterClass() {
+            val targetContext = getInstrumentation().targetContext
+            SurveyRequisite.resetRequisites(targetContext)
+            val installer = SurveyInstaller(targetContext)
+            installer.clearSurveys()
+        }
+    }
+
+    @Test
+    fun verifyRepetitionsDisplayedCorrectly() {
+        verifyRepeatHeaderText("Repetitions: 2")
+        verifyFirstIterationDisplayedInFull()
+        verifySecondIterationPartiallyDisplayed()
+    }
+
+    private fun verifyFirstIterationDisplayedInFull() {
+        onView(
+            allOf(
+                withId(R.id.input_et),
+                withQuestionViewParent(FreetextQuestionView::class.java, "205929118|0"),
+                withText("text-response-rep-one")
+            )
+        ).check(
+            matches(isDisplayed())
+        )
+
+        onView(
+            allOf(
+                withId(R.id.barcode_input),
+                withQuestionViewParent(BarcodeQuestionViewSingle::class.java, "205929119|0"),
+                withText("1234567")
+            )
+        ).check(
+            matches(isDisplayed())
+        )
+    }
+
+    private fun verifySecondIterationPartiallyDisplayed() {
+        onView(
+            allOf(
+                withId(R.id.input_et),
+                withQuestionViewParent(FreetextQuestionView::class.java, "205929118|1"),
+                withText("text-response-rep-two")
+            )
+        ).check(
+            matches(isDisplayed())
+        )
+
+        onView(
+            allOf(
+                withId(R.id.barcode_input),
+                withQuestionViewParent(BarcodeQuestionViewSingle::class.java, "205929119|1"),
+                withText("")
+            )
+        ).check(
+            matches(isDisplayed())
+        )
+    }
+}

--- a/app/src/androidTest/res/raw/repeated_one_group_form_2questions.xml
+++ b/app/src/androidTest/res/raw/repeated_one_group_form_2questions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<survey name="RepeatedForm" defaultLanguageCode="en" version='1.0' app="akvoflowsandbox"
+        surveyGroupId="207569117" surveyGroupName="RepeatedGroup" surveyId="200389118">
+    <questionGroup repeatable="true">
+        <heading>RepeatedTextGroup</heading>
+        <question order="1" type="free" mandatory="true" localeNameFlag="false" id="205929118">
+            <text>RepeatedTextQuestion</text>
+        </question>
+        <question order="2" type="scan" mandatory="true" localeNameFlag="false" id="205929119">
+            <text>RepeatedBarcode</text>
+        </question>
+    </questionGroup>
+</survey>

--- a/app/src/main/java/org/akvo/flow/ui/view/QuestionGroupTab.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/QuestionGroupTab.java
@@ -201,15 +201,31 @@ public class QuestionGroupTab extends ConstraintLayout
         }
     }
 
+    //TODO: this method should be refactored to find a better way to distinguish between
+    //repeatable and non repeatable groups
     private void displayResponses() {
         Map<String, QuestionResponse> responses = mSurveyListener.getResponses();
         for (QuestionView qv : mQuestionViews.values()) {
             String questionId = qv.getQuestion().getId();
+            /*
+             * This works for questions without repetitions in format 123456
+             * or the questions whose repetition is not 0 the the key is 123456|1
+             */
             if (responses.containsKey(questionId)) {
                 qv.rehydrate(responses.get(questionId));
             } else if (qv.getQuestion().isRepeatable() && !TextUtils.isEmpty(questionId)) {
-                questionId = questionId.split("\\|")[0];
-                if (responses.containsKey(questionId)) {
+                String[] questionIdRepetition = questionId.split("\\|");
+                questionId = questionIdRepetition[0];
+                int repetition = 0;
+                if (questionIdRepetition.length > 1) {
+                    repetition = Integer.parseInt(questionIdRepetition[1]);
+                }
+                /*
+                 * First rep (or rep 0), its questionId is in format 123456
+                 * after the second rep, the questionId format is 123451|1 etc...
+                 * So only the first repetition needs to be updated this way
+                 */
+                if (repetition == 0 && responses.containsKey(questionId)) {
                     qv.rehydrate(responses.get(questionId));
                 }
             }

--- a/app/src/main/java/org/akvo/flow/ui/view/QuestionGroupTab.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/QuestionGroupTab.java
@@ -201,7 +201,6 @@ public class QuestionGroupTab extends ConstraintLayout
         }
     }
 
-    //repeatable and non repeatable groups
     private void displayResponses() {
         Map<String, QuestionResponse> responses = mSurveyListener.getResponses();
         for (QuestionView qv : mQuestionViews.values()) {

--- a/app/src/main/java/org/akvo/flow/ui/view/QuestionGroupTab.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/QuestionGroupTab.java
@@ -201,7 +201,6 @@ public class QuestionGroupTab extends ConstraintLayout
         }
     }
 
-    //TODO: this method should be refactored to find a better way to distinguish between
     //repeatable and non repeatable groups
     private void displayResponses() {
         Map<String, QuestionResponse> responses = mSurveyListener.getResponses();


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
If a repeated question was left unanswered and you left the datapoint and opened the saved datapoint again, the first repetition was fine but after the second one, the responses were filled on the empty questions using the ones for the first repetition.
#### The solution
* repeated group responses will no longer be duplicated on empty questions
* added comments to explain and a TODO
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [x] Added an explanation about the work done
* [x] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header
* [ ] Formatted the code per our style guide
* [ ] Added a documentation (if relevant)
