### PR TITLE
[#1572] added way to fix a stuck datapoint by pressing sync in settings

### DIFF
--- a/app/src/main/java/org/akvo/flow/broadcast/UpdateReceiver.java
+++ b/app/src/main/java/org/akvo/flow/broadcast/UpdateReceiver.java
@@ -24,43 +24,13 @@ import android.content.Context;
 import android.content.Intent;
 
 import org.akvo.flow.service.DataFixWorker;
-import org.akvo.flow.service.DataPointUploadWorker;
-
-import java.util.concurrent.TimeUnit;
-
-import androidx.work.Constraints;
-import androidx.work.ExistingWorkPolicy;
-import androidx.work.NetworkType;
-import androidx.work.OneTimeWorkRequest;
-import androidx.work.WorkManager;
 
 public class UpdateReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
         if (Intent.ACTION_MY_PACKAGE_REPLACED.equals(intent.getAction())) {
-            Constraints constraints = new Constraints.Builder()
-                    .setRequiresStorageNotLow(true)
-                    .build();
-            OneTimeWorkRequest dataFixRequest = new OneTimeWorkRequest
-                    .Builder(DataFixWorker.class)
-                    .setInitialDelay(0, TimeUnit.SECONDS)
-                    .setConstraints(constraints)
-                    .addTag(DataFixWorker.TAG)
-                    .build();
-            Constraints uploadConstraints = new Constraints.Builder()
-                    .setRequiredNetworkType(NetworkType.UNMETERED)
-                    .build();
-            OneTimeWorkRequest uploadWorkRequest = new OneTimeWorkRequest.Builder(
-                    DataPointUploadWorker.class)
-                    .setInitialDelay(0, TimeUnit.SECONDS)
-                    .setConstraints(uploadConstraints)
-                    .addTag(DataPointUploadWorker.TAG)
-                    .build();
-            WorkManager.getInstance(context.getApplicationContext())
-                    .beginUniqueWork(DataFixWorker.TAG, ExistingWorkPolicy.REPLACE, dataFixRequest)
-                    .then(uploadWorkRequest)
-                    .enqueue();
+            DataFixWorker.scheduleWork(context, false);
         }
     }
 }

--- a/app/src/main/java/org/akvo/flow/broadcast/UpdateReceiver.java
+++ b/app/src/main/java/org/akvo/flow/broadcast/UpdateReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ * Copyright (C) 2019-2020 Stichting Akvo (Akvo Foundation)
  *
  * This file is part of Akvo Flow.
  *

--- a/app/src/main/java/org/akvo/flow/presentation/settings/PreferenceActivity.java
+++ b/app/src/main/java/org/akvo/flow/presentation/settings/PreferenceActivity.java
@@ -28,6 +28,7 @@ import android.view.View;
 import android.widget.ProgressBar;
 import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.google.android.material.appbar.AppBarLayout;
 
@@ -35,13 +36,13 @@ import org.akvo.flow.BuildConfig;
 import org.akvo.flow.R;
 import org.akvo.flow.app.FlowApp;
 import org.akvo.flow.injector.component.ApplicationComponent;
-import org.akvo.flow.uicomponents.BackActivity;
 import org.akvo.flow.injector.component.DaggerViewComponent;
 import org.akvo.flow.injector.component.ViewComponent;
-import org.akvo.flow.uicomponents.SnackBarManager;
-import org.akvo.flow.service.DataPointUploadWorker;
+import org.akvo.flow.service.DataFixWorker;
 import org.akvo.flow.tracking.TrackingHelper;
 import org.akvo.flow.ui.Navigator;
+import org.akvo.flow.uicomponents.BackActivity;
+import org.akvo.flow.uicomponents.SnackBarManager;
 
 import java.util.Arrays;
 import java.util.List;
@@ -184,7 +185,9 @@ public class PreferenceActivity extends BackActivity implements PreferenceView,
         if (trackingHelper != null) {
             trackingHelper.logUploadDataEvent();
         }
-        DataPointUploadWorker.scheduleUpload(getApplicationContext(), enableDataSc.isChecked());
+        Toast.makeText(getApplicationContext(), R.string.data_upload_will_start_message,
+                Toast.LENGTH_LONG).show();
+        DataFixWorker.scheduleWork(getApplicationContext(), enableDataSc.isChecked());
         finish();
     }
 

--- a/app/src/main/java/org/akvo/flow/presentation/settings/PreferenceActivity.java
+++ b/app/src/main/java/org/akvo/flow/presentation/settings/PreferenceActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Stichting Akvo (Akvo Foundation)
+ * Copyright (C) 2017-2020 Stichting Akvo (Akvo Foundation)
  *
  * This file is part of Akvo Flow.
  *

--- a/app/src/main/java/org/akvo/flow/service/DataFixWorker.java
+++ b/app/src/main/java/org/akvo/flow/service/DataFixWorker.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017-2019 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2017-2020 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo Flow.
  *

--- a/app/src/main/java/org/akvo/flow/service/DataPointUploadWorker.java
+++ b/app/src/main/java/org/akvo/flow/service/DataPointUploadWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Stichting Akvo (Akvo Foundation)
+ * Copyright (C) 2018-2020 Stichting Akvo (Akvo Foundation)
  *
  * This file is part of Akvo Flow.
  *

--- a/app/src/main/java/org/akvo/flow/service/DataPointUploadWorker.java
+++ b/app/src/main/java/org/akvo/flow/service/DataPointUploadWorker.java
@@ -86,7 +86,7 @@ public class DataPointUploadWorker extends Worker {
     public Result doWork() {
         NotificationHelper.showSyncingNotification(getApplicationContext());
         checkDeviceNotification();
-        NotificationHelper.hideSyncingNotification(getApplicationContext());
+        NotificationHelper.hidePendingNotification(getApplicationContext());
         return Result.success();
     }
 

--- a/app/src/main/java/org/akvo/flow/util/NotificationHelper.java
+++ b/app/src/main/java/org/akvo/flow/util/NotificationHelper.java
@@ -26,17 +26,18 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-import androidx.core.app.NotificationCompat;
-import androidx.core.app.TaskStackBuilder;
-import androidx.core.content.ContextCompat;
 import android.text.TextUtils;
 
 import org.akvo.flow.R;
 import org.akvo.flow.activity.SurveyActivity;
 
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.TaskStackBuilder;
+import androidx.core.content.ContextCompat;
+
 public class NotificationHelper {
 
-    private static final int SYNCING_NOTIFICATION_ID = 1235;
+    private static final int PENDING_WORK_NOTIFICATION_ID = 1235;
 
     private NotificationHelper() {
     }
@@ -115,21 +116,30 @@ public class NotificationHelper {
 
     public static void showSyncingNotification(Context context) {
         String title = context.getString(R.string.sync_service_notification_title);
+        createPendingNotification(context, title, R.string.sync_service_notification_ticker);
+    }
+
+    private static void createPendingNotification(Context context, String title, int p) {
         NotificationCompat.Builder b = new NotificationCompat.Builder(context,
                 ConstantUtil.NOTIFICATION_CHANNEL_ID)
                 .setSmallIcon(R.drawable.notification_icon)
                 .setContentTitle(title)
-                .setTicker(context.getString(R.string.sync_service_notification_ticker))
+                .setTicker(context.getString(p))
                 .setProgress(0, 0, true)
                 .setColor(ContextCompat.getColor(context, R.color.orange_main))
                 .setOngoing(true);
-        notifyWithDummyIntent(context, SYNCING_NOTIFICATION_ID, b);
+        notifyWithDummyIntent(context, PENDING_WORK_NOTIFICATION_ID, b);
     }
 
-    public static void hideSyncingNotification(Context context) {
+    public static void showCheckingNotification(Context context) {
+        String title = context.getString(R.string.check_service_notification_title);
+        createPendingNotification(context, title, R.string.check_service_notification_ticker);
+    }
+
+    public static void hidePendingNotification(Context context) {
         NotificationManager notificationManager =
                 (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        notificationManager.cancel(SYNCING_NOTIFICATION_ID);
+        notificationManager.cancel(PENDING_WORK_NOTIFICATION_ID);
     }
 
     private static void notifyWithDummyIntent(Context context, int notificationId,

--- a/app/src/main/java/org/akvo/flow/util/NotificationHelper.java
+++ b/app/src/main/java/org/akvo/flow/util/NotificationHelper.java
@@ -119,12 +119,12 @@ public class NotificationHelper {
         createPendingNotification(context, title, R.string.sync_service_notification_ticker);
     }
 
-    private static void createPendingNotification(Context context, String title, int p) {
+    private static void createPendingNotification(Context context, String title, int tickerRes) {
         NotificationCompat.Builder b = new NotificationCompat.Builder(context,
                 ConstantUtil.NOTIFICATION_CHANNEL_ID)
                 .setSmallIcon(R.drawable.notification_icon)
                 .setContentTitle(title)
-                .setTicker(context.getString(p))
+                .setTicker(context.getString(tickerRes))
                 .setProgress(0, 0, true)
                 .setColor(ContextCompat.getColor(context, R.color.orange_main))
                 .setOngoing(true);

--- a/app/src/main/java/org/akvo/flow/util/NotificationHelper.java
+++ b/app/src/main/java/org/akvo/flow/util/NotificationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Stichting Akvo (Akvo Foundation)
+ * Copyright (C) 2016-2020 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo Flow.
  *

--- a/uicomponents/src/main/res/values/strings.xml
+++ b/uicomponents/src/main/res/values/strings.xml
@@ -282,6 +282,8 @@
 
     <string name="sync_service_notification_title">Syncing data</string>
     <string name="sync_service_notification_ticker">Syncing</string>
+    <string name="check_service_notification_title">Checking submitted data...</string>
+    <string name="check_service_notification_ticker">Verifying</string>
     <string name="form_submit_error">Error submitting form, please try again</string>
 
     <string name="media_from_camera">Camera</string>
@@ -345,6 +347,7 @@
     <string name="geoshape_properties_area">Area: %1$s</string>
     <string name="geoshape_properties_title">Properties</string>
     <string name="image_location_coordinates">lat: %1$s\nlon: %2$s</string>
+    <string name="data_upload_will_start_message">Data upload will start when an internet connection is available</string>
 
     <plurals name="download_forms_error">
         <item quantity="one">Error downloading form</item>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When for some reason a datapoint's zip file was not submitted, because of a crash for example, that tdatapoint was stuck in "SUBMIT REQUESTED" state and would only be recreated if the app was updated.
#### The solution
When pressing sync in settings, also add the logic to recreate all datapoints that were not created properly before attempting to send it.
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header
* [ ] Formatted the code per our style guide
* [ ] Added a documentation (if relevant)
