### PR TITLE
Issue/1592 show new datapoints part 2

### DIFF
--- a/app/src/main/java/org/akvo/flow/presentation/datapoints/list/DataPointListAdapter.java
+++ b/app/src/main/java/org/akvo/flow/presentation/datapoints/list/DataPointListAdapter.java
@@ -140,30 +140,10 @@ class DataPointListAdapter extends BaseAdapter {
         statusImage.setImageResource(statusRes);
         statusView.setText(statusText);
 
-        // Alternate background
-//        int attr = position % 2 == 0 ? R.attr.listitem_bg1 : R.attr.listitem_bg2;
-//        final int res = PlatformUtil.getResource(context, attr);
-//        view.setBackgroundResource(res);
-
         if (dataPoint.wasViewed()) {
-            //            nameView.setTypeface(null, Typeface.NORMAL);
-            //            idView.setTypeface(null, Typeface.NORMAL);
-            //            dateView.setTypeface(null, Typeface.NORMAL);
-            //            distanceView.setTypeface(null, Typeface.NORMAL);
-            //            statusView.setTypeface(null, Typeface.NORMAL);
-            //            nameView.setTextColor(Color.parseColor("#212121"));
-            //            idView.setTextColor(Color.parseColor("#7a7a7a"));
-            //            dateView.setTextColor(Color.parseColor("#7a7a7a"));
-            //            distanceView.setTextColor(Color.parseColor("#7a7a7a"));
-            //            statusView.setTextColor(Color.parseColor("#7a7a7a"));
             nameView.setTypeface(null, Typeface.NORMAL);
         } else {
             nameView.setTypeface(null, Typeface.BOLD);
-            //            nameView.setTextColor(Color.parseColor("#000000"));
-            //            idView.setTextColor(Color.parseColor("#504c4c"));
-            //            dateView.setTextColor(Color.parseColor("#504c4c"));
-            //            distanceView.setTextColor(Color.parseColor("#504c4c"));
-            //            statusView.setTextColor(Color.parseColor("#504c4c"));
         }
         return view;
     }

--- a/app/src/main/java/org/akvo/flow/presentation/datapoints/list/DataPointListAdapter.java
+++ b/app/src/main/java/org/akvo/flow/presentation/datapoints/list/DataPointListAdapter.java
@@ -36,7 +36,6 @@ import org.akvo.flow.database.SurveyInstanceStatus;
 import org.akvo.flow.domain.SurveyGroup;
 import org.akvo.flow.presentation.datapoints.list.entity.ListDataPoint;
 import org.akvo.flow.util.GeoUtil;
-import org.akvo.flow.util.PlatformUtil;
 import org.ocpsoft.prettytime.PrettyTime;
 
 import java.util.ArrayList;
@@ -142,22 +141,29 @@ class DataPointListAdapter extends BaseAdapter {
         statusView.setText(statusText);
 
         // Alternate background
-        int attr = position % 2 == 0 ? R.attr.listitem_bg1 : R.attr.listitem_bg2;
-        final int res = PlatformUtil.getResource(context, attr);
-        view.setBackgroundResource(res);
+//        int attr = position % 2 == 0 ? R.attr.listitem_bg1 : R.attr.listitem_bg2;
+//        final int res = PlatformUtil.getResource(context, attr);
+//        view.setBackgroundResource(res);
 
         if (dataPoint.wasViewed()) {
+            //            nameView.setTypeface(null, Typeface.NORMAL);
+            //            idView.setTypeface(null, Typeface.NORMAL);
+            //            dateView.setTypeface(null, Typeface.NORMAL);
+            //            distanceView.setTypeface(null, Typeface.NORMAL);
+            //            statusView.setTypeface(null, Typeface.NORMAL);
+            //            nameView.setTextColor(Color.parseColor("#212121"));
+            //            idView.setTextColor(Color.parseColor("#7a7a7a"));
+            //            dateView.setTextColor(Color.parseColor("#7a7a7a"));
+            //            distanceView.setTextColor(Color.parseColor("#7a7a7a"));
+            //            statusView.setTextColor(Color.parseColor("#7a7a7a"));
             nameView.setTypeface(null, Typeface.NORMAL);
-            idView.setTypeface(null, Typeface.NORMAL);
-            dateView.setTypeface(null, Typeface.NORMAL);
-            distanceView.setTypeface(null, Typeface.NORMAL);
-            statusView.setTypeface(null, Typeface.NORMAL);
         } else {
             nameView.setTypeface(null, Typeface.BOLD);
-            idView.setTypeface(null, Typeface.BOLD);
-            dateView.setTypeface(null, Typeface.BOLD);
-            distanceView.setTypeface(null, Typeface.BOLD);
-            statusView.setTypeface(null, Typeface.BOLD);
+            //            nameView.setTextColor(Color.parseColor("#000000"));
+            //            idView.setTextColor(Color.parseColor("#504c4c"));
+            //            dateView.setTextColor(Color.parseColor("#504c4c"));
+            //            distanceView.setTextColor(Color.parseColor("#504c4c"));
+            //            statusView.setTextColor(Color.parseColor("#504c4c"));
         }
         return view;
     }

--- a/app/src/main/res/layout/datapoint_list_item.xml
+++ b/app/src/main/res/layout/datapoint_list_item.xml
@@ -1,6 +1,4 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:gravity="center_vertical"
@@ -24,7 +22,7 @@
             android:id="@+id/locale_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@color/text_primary"
+            android:textColor="#212121"
             android:textSize="18sp"
             android:textStyle="normal" />
 
@@ -32,28 +30,28 @@
             android:id="@+id/locale_id"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@color/text_primary"
+            android:textColor="#7a7a7a"
             android:textSize="16sp" />
 
         <TextView
             android:id="@+id/last_modified"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@color/text_primary"
+            android:textColor="#7a7a7a"
             android:textSize="16sp" />
 
         <TextView
             android:id="@+id/locale_distance"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@color/text_primary"
+            android:textColor="#7a7a7a"
             android:textSize="16sp" />
 
         <TextView
             android:id="@+id/status"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@color/text_primary"
+            android:textColor="#7a7a7a"
             android:textSize="14sp" />
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/datapoint_list_item.xml
+++ b/app/src/main/res/layout/datapoint_list_item.xml
@@ -22,7 +22,7 @@
             android:id="@+id/locale_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="#212121"
+            android:textColor="@color/text_primary"
             android:textSize="18sp"
             android:textStyle="normal" />
 
@@ -30,28 +30,28 @@
             android:id="@+id/locale_id"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="#7a7a7a"
+            android:textColor="@color/text_primary"
             android:textSize="16sp" />
 
         <TextView
             android:id="@+id/last_modified"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="#7a7a7a"
+            android:textColor="@color/text_primary"
             android:textSize="16sp" />
 
         <TextView
             android:id="@+id/locale_distance"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="#7a7a7a"
+            android:textColor="@color/text_primary"
             android:textSize="16sp" />
 
         <TextView
             android:id="@+id/status"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="#7a7a7a"
+            android:textColor="@color/text_primary"
             android:textSize="14sp" />
     </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
In the first part the text was bold everywhere
#### The solution
Make bold only the title when datapoints are newly downloaded
Also remove alternate background
#### Screenshots (if appropriate)
<img src="https://user-images.githubusercontent.com/923280/76320724-5ca98a80-62e1-11ea-9c1b-8739cb468cb5.png" width="200" />

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header
* [ ] Formatted the code per our style guide
* [ ] Added a documentation (if relevant)
