### PR TITLE
[#1599] improve datapoint download message

### DIFF
--- a/app/src/main/java/org/akvo/flow/presentation/datapoints/DataPointSyncSnackBarManager.java
+++ b/app/src/main/java/org/akvo/flow/presentation/datapoints/DataPointSyncSnackBarManager.java
@@ -20,13 +20,14 @@
 
 package org.akvo.flow.presentation.datapoints;
 
-import androidx.annotation.StringRes;
 import android.view.View;
 
 import org.akvo.flow.R;
 import org.akvo.flow.uicomponents.SnackBarManager;
 
 import javax.inject.Inject;
+
+import androidx.annotation.StringRes;
 
 public class DataPointSyncSnackBarManager {
 
@@ -37,7 +38,7 @@ public class DataPointSyncSnackBarManager {
         this.snackBarManager = snackBarManager;
     }
 
-    public void showSyncedResults(int numberOfSyncedItems, View rootView) {
+    public void showDownloadedResults(int numberOfSyncedItems, View rootView) {
         if (rootView != null) {
             String message = rootView.getResources()
                     .getQuantityString(R.plurals.data_points_sync_success_message,
@@ -77,7 +78,7 @@ public class DataPointSyncSnackBarManager {
         }
     }
 
-    public void showNoDataPointsToSync(View rootView) {
+    public void showNoDataPointsToDownload(View rootView) {
         if (rootView != null) {
             displaySnackBar(rootView.getContext()
                     .getString(R.string.data_points_sync_no_data_points), rootView);

--- a/app/src/main/java/org/akvo/flow/presentation/datapoints/list/DataPointsListFragment.java
+++ b/app/src/main/java/org/akvo/flow/presentation/datapoints/list/DataPointsListFragment.java
@@ -467,13 +467,13 @@ public class DataPointsListFragment extends Fragment implements LocationListener
     private void reloadMenu() {
         FragmentActivity activity = getActivity();
         if (activity != null) {
-            activity.supportInvalidateOptionsMenu();
+            activity.invalidateOptionsMenu();
         }
     }
 
     @Override
-    public void showSyncedResults(int numberOfSyncedItems) {
-        dataPointSyncSnackBarManager.showSyncedResults(numberOfSyncedItems, getView());
+    public void showDownloadedResults(int numberOfNewDataPoints) {
+        dataPointSyncSnackBarManager.showDownloadedResults(numberOfNewDataPoints, getView());
     }
 
     @Override
@@ -483,22 +483,13 @@ public class DataPointsListFragment extends Fragment implements LocationListener
 
     @Override
     public void showErrorNoNetwork() {
-        dataPointSyncSnackBarManager.showErrorNoNetwork(getView(), new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                presenter.onDownloadPressed();
-            }
-        });
+        dataPointSyncSnackBarManager.showErrorNoNetwork(getView(),
+                v -> presenter.onDownloadPressed());
     }
 
     @Override
     public void showErrorSync() {
-        dataPointSyncSnackBarManager.showErrorSync(getView(), new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                presenter.onDownloadPressed();
-            }
-        });
+        dataPointSyncSnackBarManager.showErrorSync(getView(), v -> presenter.onDownloadPressed());
     }
 
     @Override
@@ -516,7 +507,7 @@ public class DataPointsListFragment extends Fragment implements LocationListener
 
     @Override
     public void showNoDataPointsToSync() {
-        dataPointSyncSnackBarManager.showNoDataPointsToSync(getView());
+        dataPointSyncSnackBarManager.showNoDataPointsToDownload(getView());
     }
 
 //TODO: once we insert data using brite database this will no longer be necessary either

--- a/app/src/main/java/org/akvo/flow/presentation/datapoints/list/DataPointsListPresenter.java
+++ b/app/src/main/java/org/akvo/flow/presentation/datapoints/list/DataPointsListPresenter.java
@@ -176,8 +176,8 @@ public class DataPointsListPresenter implements Presenter {
             public void onSuccess(DownloadResult result) {
                 view.hideLoading();
                 if (result.getResultCode() == SUCCESS) {
-                    if (result.getNumberOfSyncedItems() > 0) {
-                        view.showSyncedResults(result.getNumberOfSyncedItems());
+                    if (result.getNumberOfNewItems() > 0) {
+                        view.showDownloadedResults(result.getNumberOfNewItems());
                     } else {
                         view.showNoDataPointsToSync();
                     }

--- a/app/src/main/java/org/akvo/flow/presentation/datapoints/list/DataPointsListView.java
+++ b/app/src/main/java/org/akvo/flow/presentation/datapoints/list/DataPointsListView.java
@@ -32,7 +32,7 @@ interface DataPointsListView {
 
     void hideLoading();
 
-    void showSyncedResults(int numberOfSyncedItems);
+    void showDownloadedResults(int numberOfSyncedItems);
 
     void showErrorNoNetwork();
 

--- a/app/src/main/java/org/akvo/flow/presentation/datapoints/map/DataPointsMapFragment.java
+++ b/app/src/main/java/org/akvo/flow/presentation/datapoints/map/DataPointsMapFragment.java
@@ -287,8 +287,8 @@ public class DataPointsMapFragment extends Fragment implements DataPointsMapView
     }
 
     @Override
-    public void showSyncedResults(int numberOfSyncedItems) {
-        dataPointSyncSnackBarManager.showSyncedResults(numberOfSyncedItems, getView());
+    public void showDownloadedResults(int numberOfNewItems) {
+        dataPointSyncSnackBarManager.showDownloadedResults(numberOfNewItems, getView());
     }
 
     @Override
@@ -309,8 +309,8 @@ public class DataPointsMapFragment extends Fragment implements DataPointsMapView
     }
 
     @Override
-    public void showNoDataPointsToSync() {
-        dataPointSyncSnackBarManager.showNoDataPointsToSync(getView());
+    public void showNoDataPointsToDownload() {
+        dataPointSyncSnackBarManager.showNoDataPointsToDownload(getView());
     }
 
     public void showFab() {

--- a/app/src/main/java/org/akvo/flow/presentation/datapoints/map/DataPointsMapPresenter.java
+++ b/app/src/main/java/org/akvo/flow/presentation/datapoints/map/DataPointsMapPresenter.java
@@ -136,10 +136,10 @@ public class DataPointsMapPresenter implements Presenter {
             public void onSuccess(DownloadResult result) {
                 view.hideProgress();
                 if (result.getResultCode() == SUCCESS) {
-                    if (result.getNumberOfSyncedItems() > 0) {
-                        view.showSyncedResults(result.getNumberOfSyncedItems());
+                    if (result.getNumberOfNewItems() > 0) {
+                        view.showDownloadedResults(result.getNumberOfNewItems());
                     } else {
-                        view.showNoDataPointsToSync();
+                        view.showNoDataPointsToDownload();
                     }
                 } else {
                     switch (result.getResultCode()) {

--- a/app/src/main/java/org/akvo/flow/presentation/datapoints/map/DataPointsMapView.java
+++ b/app/src/main/java/org/akvo/flow/presentation/datapoints/map/DataPointsMapView.java
@@ -30,7 +30,7 @@ interface DataPointsMapView {
 
     void displayDataPoints(FeatureCollection dataPoints);
 
-    void showSyncedResults(int numberOfSyncedItems);
+    void showDownloadedResults(int numberOfNewItems);
 
     void showErrorAssignmentMissing();
 
@@ -38,7 +38,7 @@ interface DataPointsMapView {
 
     void showErrorSync();
 
-    void showNoDataPointsToSync();
+    void showNoDataPointsToDownload();
 
     void hideMenu();
 

--- a/data/src/main/java/org/akvo/flow/data/repository/DataPointDataRepository.kt
+++ b/data/src/main/java/org/akvo/flow/data/repository/DataPointDataRepository.kt
@@ -74,8 +74,10 @@ class DataPointDataRepository @Inject constructor(
     private fun syncDataPoints(apiLocaleResult: ApiLocaleResult): Single<Int> {
         return dataSourceFactory.dataBaseDataSource
             .syncDataPoints(apiLocaleResult.dataPoints)
-            .andThen(downLoadImages(apiLocaleResult.dataPoints))
-            .andThen(Single.just(apiLocaleResult.dataPoints.size))
+            .flatMap {
+                downLoadImages(apiLocaleResult.dataPoints)
+                    .andThen(Single.just(it))
+            }
     }
 
     private fun downLoadImages(dataPoints: List<ApiDataPoint>): Completable {

--- a/data/src/main/java/org/akvo/flow/data/repository/DataPointDataRepository.kt
+++ b/data/src/main/java/org/akvo/flow/data/repository/DataPointDataRepository.kt
@@ -74,9 +74,9 @@ class DataPointDataRepository @Inject constructor(
     private fun syncDataPoints(apiLocaleResult: ApiLocaleResult): Single<Int> {
         return dataSourceFactory.dataBaseDataSource
             .syncDataPoints(apiLocaleResult.dataPoints)
-            .flatMap {
+            .flatMap { newDownloadedDataPointsNumber ->
                 downLoadImages(apiLocaleResult.dataPoints)
-                    .andThen(Single.just(it))
+                    .andThen(Single.just(newDownloadedDataPointsNumber))
             }
     }
 

--- a/data/src/test/java/org/akvo/flow/data/repository/DataPointDataRepositoryTest.kt
+++ b/data/src/test/java/org/akvo/flow/data/repository/DataPointDataRepositoryTest.kt
@@ -20,7 +20,6 @@
 package org.akvo.flow.data.repository
 
 import com.nhaarman.mockitokotlin2.spy
-import io.reactivex.Completable
 import io.reactivex.Single
 import io.reactivex.observers.TestObserver
 import org.akvo.flow.data.datasource.DataSourceFactory
@@ -162,11 +161,10 @@ class DataPointDataRepositoryTest {
     @Test
     fun downloadDataPointsShouldReturnCorrectResultIfSuccess() {
         doReturn(Single.just(mockApiResponse)).`when`(spyRestApi).downloadDataPoints(anyLong())
-        doReturn(Completable.complete()).`when`(mockDatabaseDataSource)!!.syncDataPoints(
+        doReturn(Single.just(1)).`when`(mockDatabaseDataSource)!!.syncDataPoints(
             anyList()
         )
         doReturn(mockApiDataPoints).`when`(mockApiResponse)!!.dataPoints
-        doReturn(1).`when`(mockApiDataPoints)!!.size
 
         val repository =
             DataPointDataRepository(

--- a/database/src/main/java/org/akvo/flow/database/britedb/BriteSurveyDbAdapter.java
+++ b/database/src/main/java/org/akvo/flow/database/britedb/BriteSurveyDbAdapter.java
@@ -189,7 +189,7 @@ public class BriteSurveyDbAdapter {
                 datapointId);
     }
 
-    public void updateRecord(String dataPointId, ContentValues values) {
+    public boolean insertOrUpdateRecord(String dataPointId, ContentValues values) {
         String sql =
                 "SELECT " + RecordColumns.RECORD_ID + ", " + RecordColumns.VIEWED + " FROM "
                         + Tables.RECORD + " WHERE " + RecordColumns.RECORD_ID + " = ?";
@@ -210,6 +210,7 @@ public class BriteSurveyDbAdapter {
             values.put(RecordColumns.VIEWED, viewed);
         }
         briteDatabase.insert(Tables.RECORD, values);
+        return id == DOES_NOT_EXIST;
     }
 
     /**

--- a/domain/src/main/java/org/akvo/flow/domain/entity/DownloadResult.java
+++ b/domain/src/main/java/org/akvo/flow/domain/entity/DownloadResult.java
@@ -23,19 +23,19 @@ package org.akvo.flow.domain.entity;
 public class DownloadResult {
 
     private final ResultCode resultCode;
-    private final int numberOfSyncedItems;
+    private final int numberOfNewItems;
 
-    public DownloadResult(ResultCode resultCode, int numberOfSyncedItems) {
+    public DownloadResult(ResultCode resultCode, int numberOfNewItems) {
         this.resultCode = resultCode;
-        this.numberOfSyncedItems = numberOfSyncedItems;
+        this.numberOfNewItems = numberOfNewItems;
     }
 
     public ResultCode getResultCode() {
         return resultCode;
     }
 
-    public int getNumberOfSyncedItems() {
-        return numberOfSyncedItems;
+    public int getNumberOfNewItems() {
+        return numberOfNewItems;
     }
 
     public enum ResultCode {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
The message is misleading, we say x datapoints downloaded even if there is nothing new but the same old datapoints
#### The solution
* display the number of new downloaded datapoints
* rename some methods related to datapoint download
* some "formatting" fixes
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header
* [ ] Formatted the code per our style guide
* [ ] Added a documentation (if relevant)
