### PR TITLE
[#1620] remove divider from list footer and header

### DIFF
--- a/app/src/main/java/org/akvo/flow/ui/view/SubmitTab.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/SubmitTab.java
@@ -20,8 +20,6 @@
 package org.akvo.flow.ui.view;
 
 import android.content.Context;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -37,6 +35,9 @@ import org.akvo.flow.event.SurveyListener;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 public class SubmitTab extends ListView implements OnClickListener {
 
@@ -64,7 +65,8 @@ public class SubmitTab extends ListView implements OnClickListener {
 
         mSubmitButton = (Button) inflate(context, R.layout.submit_tab_footer);
         mSubmitButton.setOnClickListener(this);
-
+        setFooterDividersEnabled(false);
+        setHeaderDividersEnabled(false);
         addHeaderView(mHeaderView);
         addFooterView(mSubmitButton, FOOTER, true);
         adapter = new QuestionListAdapter();


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
NA
#### The solution
Unexpected divider in Submit Tab footer needs to be removed.
#### Screenshots (if appropriate)
<img src="https://user-images.githubusercontent.com/923280/79423978-c9d6cc80-7fbf-11ea-978d-863536a7ff7d.png" width="200" />

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header
* [ ] Formatted the code per our style guide
* [ ] Added a documentation (if relevant)
