### PR TITLE
Issue/1611 form download

### DIFF
--- a/app/src/main/java/org/akvo/flow/activity/SurveyActivity.java
+++ b/app/src/main/java/org/akvo/flow/activity/SurveyActivity.java
@@ -153,6 +153,7 @@ public class SurveyActivity extends AppCompatActivity implements RecordListListe
     private boolean activityJustCreated;
     private boolean permissionsResults;
     private TrackingHelper trackingHelper;
+    private boolean servicesStarted = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -165,6 +166,7 @@ public class SurveyActivity extends AppCompatActivity implements RecordListListe
         initializeToolBar();
         presenter.setView(this);
         trackingHelper = new TrackingHelper(this);
+        servicesStarted = false;
         if (!deviceSetUpCompleted()) {
             navigateToSetUp();
         } else {
@@ -374,16 +376,19 @@ public class SurveyActivity extends AppCompatActivity implements RecordListListe
 
     private void startServicesIfPossible() {
         if (StatusUtil.hasExternalStorage()) {
-            startServices();
+            startServicesOnce();
         } else {
             displayExternalStorageMissing();
         }
     }
 
-    private void startServices() {
-        startService(new Intent(this, SurveyDownloadService.class));
-        startService(new Intent(this, BootstrapService.class));
-        startService(new Intent(this, TimeCheckService.class));
+    private void startServicesOnce() {
+        if (!servicesStarted) {
+            startService(new Intent(this, SurveyDownloadService.class));
+            startService(new Intent(this, BootstrapService.class));
+            startService(new Intent(this, TimeCheckService.class));
+            servicesStarted = true;
+        }
     }
 
     private void displayExternalStorageMissing() {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
NA
#### The solution
The forms are downloaded too often with the fix introduced in the #1611, make sure forms download and other services only started once when activity is created
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header
* [ ] Formatted the code per our style guide
* [ ] Added a documentation (if relevant)
