### PR TITLE
[#1637] updated text for geoshape button

### DIFF
--- a/app/src/main/java/org/akvo/flow/ui/view/GeoshapeQuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/GeoshapeQuestionView.java
@@ -72,7 +72,9 @@ public class GeoshapeQuestionView extends QuestionView implements OnClickListene
     }
 
     private void displayResponseView() {
-        mResponseView.setVisibility(TextUtils.isEmpty(mValue) ? GONE : VISIBLE);
+        boolean empty = TextUtils.isEmpty(mValue);
+        mResponseView.setVisibility(empty ? GONE : VISIBLE);
+        mMapBtn.setText(empty ? R.string.capture_shape: R.string.edit_shape);
     }
 
     @Override

--- a/uicomponents/src/main/res/values/strings.xml
+++ b/uicomponents/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="type_code">type code</string>
     <string name="or">or</string>
     <string name="capture_shape">capture shape</string>
+    <string name="edit_shape">edit shape</string>
     <string name="view_shape">view shape</string>
     <string name="delete_point_title">Delete point?</string>
     <string name="delete_shape_title">Delete shape?</string>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
The button text was inconsistent
#### The solution
Update the button text once a shape has already been captured
#### Screenshots (if appropriate)
<img src="https://user-images.githubusercontent.com/923280/83517033-76213380-a4d8-11ea-880c-d53408a30e41.png" width="200" />

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header
* [ ] Formatted the code per our style guide
* [ ] Added a documentation (if relevant)
