### PR TITLE
[#1199] adds "auto-save" to geoshapes

### DIFF
--- a/app/src/main/java/org/akvo/flow/presentation/geoshape/create/CreateGeoShapeActivity.java
+++ b/app/src/main/java/org/akvo/flow/presentation/geoshape/create/CreateGeoShapeActivity.java
@@ -362,6 +362,11 @@ public class CreateGeoShapeActivity extends BackActivity implements
         return super.onOptionsItemSelected(item);
     }
 
+    @Override
+    public void onBackPressed() {
+        presenter.onBackPressed(changed);
+    }
+
     private void enableNewShapeType(DrawMode drawMode) {
         if (this.drawMode != drawMode) {
             presenter.onNewDrawModePressed(drawMode);

--- a/app/src/main/java/org/akvo/flow/presentation/geoshape/create/CreateGeoShapePresenter.java
+++ b/app/src/main/java/org/akvo/flow/presentation/geoshape/create/CreateGeoShapePresenter.java
@@ -169,7 +169,15 @@ public class CreateGeoShapePresenter implements Presenter {
         view.displayNewMapStyle(viewFeatures);
     }
 
+    public void onBackPressed(boolean changed) {
+        saveShape(changed);
+    }
+
     public void onSavePressed(boolean changed) {
+        saveShape(changed);
+    }
+
+    private void saveShape(boolean changed) {
         if (isValidShape() && changed) {
             String featureString = featureMapper.createFeaturesToSave(shapes);
             view.setShapeResult(featureString);


### PR DESCRIPTION
### Before the PR (what is the issue or what needed to be done)
NA
#### The solution
Now when user pressed the device back button or the top toolbar button,
the shape will be saved and added as result to the form
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header
* [ ] Formatted the code per our style guide
* [ ] Added a documentation (if relevant)
