### PR TITLE
[#1680] do not display the accuracy tip when no location data yet

### DIFF
--- a/app/src/main/java/org/akvo/flow/ui/view/geolocation/GeoInputContainer.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/geolocation/GeoInputContainer.java
@@ -182,7 +182,11 @@ public class GeoInputContainer extends CoordinatorLayout {
 
     void showCoordinatesInaccurate() {
         statusIndicator.setTextColor(Color.RED);
-        accuracyWarning.setVisibility(VISIBLE);
+        if (hasLocation()) {
+            accuracyWarning.setVisibility(VISIBLE);
+        } else {
+            accuracyWarning.setVisibility(GONE);
+        }
     }
 
     void showLocationListenerStopped() {

--- a/app/src/main/java/org/akvo/flow/ui/view/geolocation/GeoQuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/geolocation/GeoQuestionView.java
@@ -134,7 +134,6 @@ public class GeoQuestionView extends QuestionView
     public void startListeningToLocation() {
         resetQuestion(true);
         showLocationListenerStarted();
-        resetAccuracy();
         mLocationListener.startLocationIfPossible();
     }
 
@@ -176,9 +175,6 @@ public class GeoQuestionView extends QuestionView
 
     private void updateButtonTextToCancel() {
         mGeoButton.setText(R.string.cancelbutton);
-    }
-
-    private void resetAccuracy() {
     }
 
     @Override
@@ -238,7 +234,6 @@ public class GeoQuestionView extends QuestionView
     @Override
     public void resetQuestion(boolean fireEvent) {
         super.resetQuestion(fireEvent);
-        resetAccuracy();
         geoInputContainer.displayCoordinates("", "", "");
     }
 
@@ -269,7 +264,6 @@ public class GeoQuestionView extends QuestionView
         showLocationListenerStopped();
         View coordinatorLayout = getRootView().findViewById(R.id.coordinator_layout);
         locationSnackBarManager.displayLocationTimeoutSnackBar(coordinatorLayout, v -> {
-            resetAccuracy();
             mLocationListener.startLocationIfPossible();
             showLocationListenerStarted();
         }, getContext());


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
The accuracy tip shown even if we have no location data yet
#### The solution
do not display the accuracy tip when no location data yet
+ removed empty method
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header
* [ ] Formatted the code per our style guide
* [ ] Added a documentation (if relevant)
