### PR TITLE
[#1722] Fixed location issue

### DIFF
--- a/app/src/main/java/org/akvo/flow/event/TimedLocationListener.java
+++ b/app/src/main/java/org/akvo/flow/event/TimedLocationListener.java
@@ -73,6 +73,11 @@ public class TimedLocationListener implements LocationListener {
             return;
         }
 
+        Listener listener = listenerWeakReference.get();
+        if (listener != null) {
+            listener.onLocationStarted();
+        }
+
         mLocationManager
                 .requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0, weakLocationListener);
         mListeningLocation = true;
@@ -85,15 +90,12 @@ public class TimedLocationListener implements LocationListener {
             @Override
             public void run() {
                 // Ensure it runs on the UI thread!
-                mHandler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        if (mListeningLocation) {
-                            stop();
-                            Listener listener = listenerWeakReference.get();
-                            if (listener != null) {
-                                listener.onTimeout();
-                            }
+                mHandler.post(() -> {
+                    if (mListeningLocation) {
+                        stop();
+                        Listener listener1 = listenerWeakReference.get();
+                        if (listener1 != null) {
+                            listener1.onTimeout();
                         }
                     }
                 });
@@ -156,6 +158,8 @@ public class TimedLocationListener implements LocationListener {
     }
 
     public interface Listener {
+
+        void onLocationStarted();
 
         void onLocationReady(double latitude, double longitude, double altitude, float accuracy);
 

--- a/app/src/main/java/org/akvo/flow/ui/view/geolocation/GeoQuestionView.java
+++ b/app/src/main/java/org/akvo/flow/ui/view/geolocation/GeoQuestionView.java
@@ -133,7 +133,6 @@ public class GeoQuestionView extends QuestionView
 
     public void startListeningToLocation() {
         resetQuestion(true);
-        showLocationListenerStarted();
         mLocationListener.startLocationIfPossible();
     }
 
@@ -190,6 +189,11 @@ public class GeoQuestionView extends QuestionView
                 .displayPermissionMissingSnackBar(coordinatorLayout,
                         v -> startListeningToLocation(),
                         getContext());
+    }
+
+    @Override
+    public void onLocationStarted() {
+        showLocationListenerStarted();
     }
 
     @Override


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When user requested location capture but location provider was disabled
the snackbar was not shown and the "loading" ui was displayed incorrectly
#### The solution
Fixed: only once the location is being listened to, we display the loading ui
#### Screenshots (if appropriate)
![Screenshot_20200922-163638](https://user-images.githubusercontent.com/923280/93896985-dccd9580-fcf1-11ea-8e05-ffe7db2f7152.png)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header
* [ ] Formatted the code per our style guide
* [ ] Added a documentation (if relevant)
