### PR TITLE
[#1754] drawer new dot display

### DIFF
--- a/app/proguard-files/proguard-rules.pro
+++ b/app/proguard-files/proguard-rules.pro
@@ -33,6 +33,9 @@
     public <init>(android.content.Context, android.util.AttributeSet, int);
 }
 
+-keep class androidx.appcompat.app.ActionBarDrawerToggle { *; }
+-keep class androidx.appcompat.app.ActionBarDrawerToggle$Delegate { *; }
+
 # Samsung Android 4.2 bug workaround
 -keep class !android.support.v7.view.menu.**,!android.support.design.internal.NavigationMenu,!android.support.design.internal.NavigationMenuPresenter,!android.support.design.internal.NavigationSubMenu,** {*;}
 

--- a/app/src/main/java/org/akvo/flow/activity/SurveyActivity.java
+++ b/app/src/main/java/org/akvo/flow/activity/SurveyActivity.java
@@ -55,7 +55,6 @@ import org.akvo.flow.domain.SurveyGroup;
 import org.akvo.flow.domain.entity.User;
 import org.akvo.flow.domain.interactor.DefaultObserver;
 import org.akvo.flow.domain.interactor.users.GetSelectedUser;
-import org.akvo.flow.domain.util.VersionHelper;
 import org.akvo.flow.injector.component.ApplicationComponent;
 import org.akvo.flow.injector.component.DaggerViewComponent;
 import org.akvo.flow.injector.component.ViewComponent;
@@ -71,12 +70,14 @@ import org.akvo.flow.presentation.navigation.EditUserDialog;
 import org.akvo.flow.presentation.navigation.FlowNavigationView;
 import org.akvo.flow.presentation.navigation.SurveyDeleteConfirmationDialog;
 import org.akvo.flow.presentation.navigation.UserOptionsDialog;
+import org.akvo.flow.presentation.navigation.ViewSurvey;
 import org.akvo.flow.presentation.navigation.ViewUser;
+import org.akvo.flow.presentation.survey.CustomDrawerArrowDrawable;
 import org.akvo.flow.presentation.survey.SurveyPresenter;
 import org.akvo.flow.presentation.survey.SurveyView;
-import org.akvo.flow.service.bootstrap.BootstrapWorker;
 import org.akvo.flow.service.SurveyDownloadWorker;
 import org.akvo.flow.service.TimeCheckService;
+import org.akvo.flow.service.bootstrap.BootstrapWorker;
 import org.akvo.flow.tracking.TrackingHelper;
 import org.akvo.flow.tracking.TrackingListener;
 import org.akvo.flow.ui.Navigator;
@@ -87,6 +88,7 @@ import org.akvo.flow.uicomponents.SnackBarManager;
 import org.akvo.flow.util.AppPermissionsHelper;
 import org.akvo.flow.util.ConstantUtil;
 import org.akvo.flow.util.ViewUtil;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -142,9 +144,6 @@ public class SurveyActivity extends AppCompatActivity implements RecordListListe
     AppPermissionsHelper appPermissionsHelper;
 
     @Inject
-    VersionHelper versionHelper;
-
-    @Inject
     SurveyPresenter presenter;
 
     private SurveyGroup mSurveyGroup;
@@ -157,6 +156,7 @@ public class SurveyActivity extends AppCompatActivity implements RecordListListe
     private boolean permissionsResults;
     private TrackingHelper trackingHelper;
     private boolean servicesStarted = false;
+    private CustomDrawerArrowDrawable customDrawerArrowDrawable;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -319,7 +319,8 @@ public class SurveyActivity extends AppCompatActivity implements RecordListListe
     private void initNavigationDrawer() {
         mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout,
                 R.string.drawer_open, R.string.drawer_close);
-
+        customDrawerArrowDrawable = new CustomDrawerArrowDrawable(getSupportActionBar().getThemedContext());
+        mDrawerToggle.setDrawerArrowDrawable(customDrawerArrowDrawable);
         mDrawerLayout.addDrawerListener(mDrawerToggle);
         if (mSurveyGroup == null) {
             mDrawerLayout.openDrawer(GravityCompat.START);
@@ -654,6 +655,13 @@ public class SurveyActivity extends AppCompatActivity implements RecordListListe
         navigate(() -> navigator.navigateToOfflineAreasList(SurveyActivity.this));
     }
 
+    @Override
+    public void updateDrawerIcon(@NotNull List<ViewSurvey> newSurveys) {
+        if (customDrawerArrowDrawable != null) {
+            customDrawerArrowDrawable.setEnabled(newSurveys.size() > 0);
+        }
+    }
+
     private void navigate(Runnable runnable) {
         mDrawerLayout.closeDrawers();
         mDrawerLayout.postDelayed(runnable, NAVIGATION_DRAWER_DELAY_MILLIS);
@@ -747,4 +755,5 @@ public class SurveyActivity extends AppCompatActivity implements RecordListListe
     public void onWindowSelected(String id) {
         onDatapointSelected(id);
     }
+
 }

--- a/app/src/main/java/org/akvo/flow/presentation/navigation/FlowNavigationView.kt
+++ b/app/src/main/java/org/akvo/flow/presentation/navigation/FlowNavigationView.kt
@@ -204,6 +204,10 @@ class FlowNavigationView @JvmOverloads constructor(
 
     override fun displaySurveys(surveys: List<ViewSurvey>, selectedSurveyId: Long?) {
         surveyAdapter.setSurveys(surveys, selectedSurveyId!!)
+        val newSurveys = surveys.filter {
+            !it.viewed
+        }
+        drawerNavigationListener?.updateDrawerIcon(newSurveys)
     }
 
     override fun notifySurveyDeleted(surveyGroupId: Long) {
@@ -296,5 +300,6 @@ class FlowNavigationView @JvmOverloads constructor(
         fun navigateToAbout()
         fun navigateToSettings()
         fun navigateToOfflineMaps()
+        fun updateDrawerIcon(newSurveys: List<ViewSurvey>)
     }
 }

--- a/app/src/main/java/org/akvo/flow/presentation/survey/CustomDrawerArrowDrawable.kt
+++ b/app/src/main/java/org/akvo/flow/presentation/survey/CustomDrawerArrowDrawable.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021 Stichting Akvo (Akvo Foundation)
+ *
+ * This file is part of Akvo Flow.
+ *
+ * Akvo Flow is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Akvo Flow is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Akvo Flow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.akvo.flow.presentation.survey
+
+import android.content.Context
+import android.graphics.Canvas
+import androidx.appcompat.graphics.drawable.DrawerArrowDrawable
+import org.akvo.flow.R
+
+class CustomDrawerArrowDrawable(context: Context) : DrawerArrowDrawable(context) {
+
+    private val customDrawable = context.resources.getDrawable(R.drawable.ic_new_forms_icon, null)
+    var isEnabled = false
+
+    override fun draw(canvas: Canvas) {
+        if (isEnabled) {
+            customDrawable.setBounds(bounds.left, bounds.top, bounds.right, bounds.bottom)
+            customDrawable.draw(canvas)
+        } else {
+            super.draw(canvas)
+        }
+    }
+
+}

--- a/app/src/main/res/drawable/ic_new_forms_icon.xml
+++ b/app/src/main/res/drawable/ic_new_forms_icon.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M3,18H21V16H3V18ZM3,13H21V11H3V13ZM3,6V8H21V6H3Z"
+      android:fillColor="#ffffff"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M22,4C22.5304,4 23.0391,3.7893 23.4142,3.4142C23.7893,3.0391 24,2.5304 24,2C24,1.4696 23.7893,0.9609 23.4142,0.5858C23.0391,0.2107 22.5304,0 22,0C21.4696,0 20.9609,0.2107 20.5858,0.5858C20.2107,0.9609 20,1.4696 20,2C20,2.5304 20.2107,3.0391 20.5858,3.4142C20.9609,3.7893 21.4696,4 22,4V4Z"
+      android:fillColor="#ffffff"
+      android:fillType="evenOdd"/>
+</vector>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
User does not know there are newly downloaded forms without opening the navigation drawer
#### The solution
display a dot on top of the drawer toggle icon when there are new forms
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header
* [ ] Formatted the code per our style guide
* [ ] Added a documentation (if relevant)
