### PR TITLE
[#1754] fix crash on Android 4 devices for a method which did not exist

### DIFF
--- a/app/src/main/java/org/akvo/flow/presentation/survey/CustomDrawerArrowDrawable.kt
+++ b/app/src/main/java/org/akvo/flow/presentation/survey/CustomDrawerArrowDrawable.kt
@@ -20,18 +20,22 @@ package org.akvo.flow.presentation.survey
 
 import android.content.Context
 import android.graphics.Canvas
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.graphics.drawable.DrawerArrowDrawable
 import org.akvo.flow.R
 
 class CustomDrawerArrowDrawable(context: Context) : DrawerArrowDrawable(context) {
 
-    private val customDrawable = context.resources.getDrawable(R.drawable.ic_new_forms_icon, null)
+    private val customDrawable = AppCompatResources.getDrawable(context, R.drawable.ic_new_forms_icon)
+
     var isEnabled = false
 
     override fun draw(canvas: Canvas) {
         if (isEnabled) {
-            customDrawable.setBounds(bounds.left, bounds.top, bounds.right, bounds.bottom)
-            customDrawable.draw(canvas)
+            customDrawable?.let {
+                customDrawable.setBounds(bounds.left, bounds.top, bounds.right, bounds.bottom)
+                customDrawable.draw(canvas)
+            }
         } else {
             super.draw(canvas)
         }


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

#### The solution
There was a crash on Android 4 devices because a method was added later
#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header
* [ ] Formatted the code per our style guide
* [ ] Added a documentation (if relevant)
